### PR TITLE
Fix service sandboxing that blocked session startup and cert generation

### DIFF
--- a/crates/termland-server/src/main.rs
+++ b/crates/termland-server/src/main.rs
@@ -40,9 +40,10 @@ struct Args {
     tls_key: Option<String>,
 
     /// Generate the self-signed TLS keypair if it is missing, then exit.
-    /// Run by termland-server-keygen.service before the main service starts,
-    /// because the service itself runs under ProtectSystem=strict and cannot
-    /// write /etc/pki/termland. Idempotent — an existing keypair is kept.
+    /// Run at install time by the RPM, because the service itself runs under
+    /// ProtectSystem=strict and cannot write /etc/pki/termland. Also the
+    /// command to run by hand if the keypair is ever missing. Idempotent — an
+    /// existing keypair is kept.
     #[arg(long)]
     generate_cert: bool,
 

--- a/crates/termland-server/src/main.rs
+++ b/crates/termland-server/src/main.rs
@@ -25,8 +25,9 @@ struct Args {
     #[arg(short, long, default_value = "127.0.0.1")]
     bind: String,
 
-    /// Enable TLS for TCP connections. Auto-generates a self-signed cert
-    /// in ~/.config/termland/ if no --tls-cert/--tls-key is provided.
+    /// Enable TLS for TCP connections. Auto-generates a self-signed cert in
+    /// /etc/pki/termland/ (root) or ~/.config/termland/ (unprivileged) if no
+    /// --tls-cert/--tls-key is provided.
     #[arg(long)]
     tls: bool,
 
@@ -37,6 +38,13 @@ struct Args {
     /// Path to TLS private key PEM file (implies --tls)
     #[arg(long)]
     tls_key: Option<String>,
+
+    /// Generate the self-signed TLS keypair if it is missing, then exit.
+    /// Run by termland-server-keygen.service before the main service starts,
+    /// because the service itself runs under ProtectSystem=strict and cannot
+    /// write /etc/pki/termland. Idempotent — an existing keypair is kept.
+    #[arg(long)]
+    generate_cert: bool,
 
     /// Require PAM authentication before session creation.
     /// Uses the "termland" PAM service, falling back to "login".
@@ -117,6 +125,15 @@ async fn main() -> Result<()> {
         )
         .with_writer(std::io::stderr)
         .init();
+
+    if args.generate_cert {
+        let cert = args.tls_cert.as_deref().map(std::path::Path::new);
+        let key = args.tls_key.as_deref().map(std::path::Path::new);
+        let (cert, key) = tls::generate_if_missing(cert, key)?;
+        tracing::info!("TLS certificate: {}", cert.display());
+        tracing::info!("TLS private key:  {}", key.display());
+        return Ok(());
+    }
 
     if args.subsystem {
         tracing::info!("Starting in SSH subsystem mode");

--- a/crates/termland-server/src/quic.rs
+++ b/crates/termland-server/src/quic.rs
@@ -83,7 +83,7 @@ const MAX_CONCURRENT_SESSIONS: usize = 32;
 /// the exact same cert-loading path as `--tls` (`tls::load_or_generate_cert`
 /// via `tls::build_rustls_server_config`) rather than a separate
 /// implementation: pass `--tls-cert`/`--tls-key`, or let it auto-generate a
-/// self-signed cert in `~/.config/termland/` just like the TCP+TLS acceptor
+/// self-signed cert in `/etc/pki/termland/` just like the TCP+TLS acceptor
 /// does.
 pub async fn run_quic_listener(
     bind: &str,

--- a/crates/termland-server/src/tls.rs
+++ b/crates/termland-server/src/tls.rs
@@ -121,16 +121,16 @@ pub fn load_or_generate_cert(
 }
 
 /// Create the default keypair if it is missing, without building a rustls
-/// config around it. This is what the `termland-server-keygen.service`
-/// oneshot calls before the main service starts.
+/// config around it. Invoked as `termland-server --generate-cert`, which the
+/// RPM's `%post` runs at install time.
 ///
 /// It exists because the long-running service runs under
 /// `ProtectSystem=strict` and therefore cannot write `/etc` — the same reason
-/// `sshd` does not generate its own host keys and leaves that to
-/// `sshd-keygen@.service`, which runs unsandboxed beforehand.
+/// `mod_ssl` generates its certificate from a packaging hook rather than from
+/// httpd itself.
 ///
-/// Idempotent: an existing pair is left alone, so the unit can be re-run and
-/// the condition guard in it is only an optimisation.
+/// Idempotent: an existing pair is left alone, so `%post` can re-run on
+/// upgrade and an administrator can run it by hand to recover a lost keypair.
 pub fn generate_if_missing(
     cert_path: Option<&Path>,
     key_path: Option<&Path>,

--- a/crates/termland-server/src/tls.rs
+++ b/crates/termland-server/src/tls.rs
@@ -5,20 +5,67 @@ use rustls::ServerConfig;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
 use tokio_rustls::TlsAcceptor;
 
-fn config_dir() -> PathBuf {
-    dirs_or_default("termland")
+/// System-wide PKI location, used when running as root (i.e. as the systemd
+/// service). Follows the distro convention of `/etc/pki/<app>/` rather than
+/// `dirs::config_dir()`, which for `User=root` resolves to `/root/.config` —
+/// a path `ProtectHome=` renders read-only for any hardened unit, and not
+/// somewhere an administrator would think to look for a server's keypair.
+const SYSTEM_PKI_DIR: &str = "/etc/pki/termland";
+
+fn running_as_root() -> bool {
+    // SAFETY: geteuid() is always successful and takes no arguments.
+    unsafe { libc::geteuid() == 0 }
 }
 
-fn dirs_or_default(name: &str) -> PathBuf {
-    if let Some(config) = dirs::config_dir() {
-        config.join(name)
+fn config_dir() -> PathBuf {
+    if running_as_root() {
+        PathBuf::from(SYSTEM_PKI_DIR)
     } else {
-        PathBuf::from(format!("/etc/{name}"))
+        user_config_dir()
     }
 }
 
-fn default_cert_path() -> PathBuf { config_dir().join("cert.pem") }
-fn default_key_path() -> PathBuf { config_dir().join("key.pem") }
+fn user_config_dir() -> PathBuf {
+    if let Some(config) = dirs::config_dir() {
+        config.join("termland")
+    } else {
+        PathBuf::from("/etc/termland")
+    }
+}
+
+/// Resolve the default cert + key pair together, so the two never come from
+/// different directories.
+///
+/// Root gets `/etc/pki/termland/`; an unprivileged server (SSH-subsystem
+/// mode, or someone running it by hand) keeps `~/.config/termland/`.
+///
+/// Installations predating the `/etc/pki` move generated their keypair under
+/// `~/.config/termland/`, which for the service meant `/root/.config/termland/`.
+/// If such a pair is still there and the system one is not, keep using it:
+/// silently generating a fresh cert would change the fingerprint out from
+/// under every client that has already pinned the old one.
+fn default_cert_key() -> (PathBuf, PathBuf) {
+    let dir = config_dir();
+    let (cert, key) = (dir.join("cert.pem"), dir.join("key.pem"));
+
+    if running_as_root() && !(cert.exists() && key.exists()) {
+        let legacy = user_config_dir();
+        let (legacy_cert, legacy_key) = (legacy.join("cert.pem"), legacy.join("key.pem"));
+        if legacy_cert.exists() && legacy_key.exists() {
+            tracing::warn!(
+                "Using legacy TLS keypair in {} — the default is now {}. \
+                 Move cert.pem/key.pem there (or set --tls-cert/--tls-key) to \
+                 silence this; regenerating instead would change the \
+                 certificate fingerprint seen by existing clients.",
+                legacy.display(),
+                dir.display(),
+            );
+            return (legacy_cert, legacy_key);
+        }
+    }
+
+    (cert, key)
+}
 
 /// The crypto backend both the TCP+TLS acceptor and the QUIC listener
 /// (`crate::quic`) build their rustls configs against. Selected explicitly
@@ -40,13 +87,15 @@ fn crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
 /// place that knows how to find/create the cert, not two.
 ///
 /// If `cert_path`/`key_path` are provided, loads those. Otherwise looks in
-/// `~/.config/termland/` and auto-generates a self-signed cert if missing.
+/// `/etc/pki/termland/` (root) or `~/.config/termland/` (unprivileged) and
+/// auto-generates a self-signed cert if missing — see `default_cert_key`.
 pub fn load_or_generate_cert(
     cert_path: Option<&Path>,
     key_path: Option<&Path>,
 ) -> Result<(Vec<CertificateDer<'static>>, PrivateKeyDer<'static>)> {
-    let cert_path = cert_path.map(PathBuf::from).unwrap_or_else(default_cert_path);
-    let key_path = key_path.map(PathBuf::from).unwrap_or_else(default_key_path);
+    let (default_cert, default_key) = default_cert_key();
+    let cert_path = cert_path.map(PathBuf::from).unwrap_or(default_cert);
+    let key_path = key_path.map(PathBuf::from).unwrap_or(default_key);
 
     if !cert_path.exists() || !key_path.exists() {
         tracing::info!("No TLS certificate found, generating self-signed...");
@@ -69,6 +118,36 @@ pub fn load_or_generate_cert(
 
     tracing::info!("TLS configured with {}", cert_path.display());
     Ok((certs, key))
+}
+
+/// Create the default keypair if it is missing, without building a rustls
+/// config around it. This is what the `termland-server-keygen.service`
+/// oneshot calls before the main service starts.
+///
+/// It exists because the long-running service runs under
+/// `ProtectSystem=strict` and therefore cannot write `/etc` — the same reason
+/// `sshd` does not generate its own host keys and leaves that to
+/// `sshd-keygen@.service`, which runs unsandboxed beforehand.
+///
+/// Idempotent: an existing pair is left alone, so the unit can be re-run and
+/// the condition guard in it is only an optimisation.
+pub fn generate_if_missing(
+    cert_path: Option<&Path>,
+    key_path: Option<&Path>,
+) -> Result<(PathBuf, PathBuf)> {
+    let (default_cert, default_key) = default_cert_key();
+    let cert_path = cert_path.map(PathBuf::from).unwrap_or(default_cert);
+    let key_path = key_path.map(PathBuf::from).unwrap_or(default_key);
+
+    if cert_path.exists() && key_path.exists() {
+        tracing::info!("TLS keypair already present: {}", cert_path.display());
+        return Ok((cert_path, key_path));
+    }
+
+    generate_self_signed(&cert_path, &key_path)
+        .with_context(|| format!("generating self-signed keypair at {}", cert_path.display()))?;
+
+    Ok((cert_path, key_path))
 }
 
 /// Load or generate a TLS server configuration for the TCP+TLS acceptor.

--- a/crates/termland-server/src/transport.rs
+++ b/crates/termland-server/src/transport.rs
@@ -215,8 +215,20 @@ where
         None
     };
 
-    // Ensure the session registry directory exists.
-    let _ = crate::registry::ensure_dir();
+    // Ensure the session registry directory exists. Do not discard the error:
+    // when this fails, the session still proceeds and dies much later with a
+    // bare "open log <path>: No such file or directory" from the compositor
+    // spawn, which names the symptom and hides the cause (issue #8). The
+    // usual culprit is unit sandboxing — ProtectHome= covers /run/user, not
+    // just /home and /root — or an XDG_RUNTIME_DIR that logind has reaped.
+    if let Err(e) = crate::registry::ensure_dir() {
+        tracing::error!(
+            "Failed to create session registry directory {}: {e} \
+             (session creation will fail; check the service unit's sandboxing \
+             and XDG_RUNTIME_DIR)",
+            crate::registry::base_dir().display(),
+        );
+    }
 
     // Session control loop. The client either manages sessions (list / close) or
     // starts one — create a new persistent session, or attach to an existing one

--- a/packaging/termland-server.env
+++ b/packaging/termland-server.env
@@ -13,7 +13,9 @@ TERMLAND_PORT=7867
 # ─── TLS Encryption ──────────────────────────────────────────────────────────
 # Enable TLS for all TCP connections. Highly recommended for non-localhost.
 # If no certificate paths are given, a self-signed cert is auto-generated
-# in /root/.config/termland/ on first startup.
+# in /etc/pki/termland/ on first startup. To provision your own keypair
+# without the server ever generating one, drop cert.pem/key.pem there
+# (0600 for the key) before first start, or set explicit paths below.
 #
 # To use your own certificate (e.g. from Let's Encrypt):
 #   TERMLAND_TLS_FLAGS=--tls --tls-cert /etc/letsencrypt/live/myhost/fullchain.pem --tls-key /etc/letsencrypt/live/myhost/privkey.pem

--- a/packaging/termland-server.service
+++ b/packaging/termland-server.service
@@ -44,12 +44,37 @@ ExecStart=/usr/bin/termland-server \
 Restart=on-failure
 RestartSec=5
 
-# Security hardening
+# Security hardening.
+#
+# Scope note: this sandbox is inherited by everything the service spawns —
+# which here means whole user desktop sessions, not just a network daemon.
+# Whatever the sandbox forbids, a remote user's desktop cannot do either.
+#
+# ProtectHome= is deliberately NOT set. Per systemd.exec(5) it covers /home,
+# /root *and* /run/user, and this service must write all three: sessions
+# write to the user's home directory, the first-run TLS cert used to land
+# under /root, and each isolated session needs its own /run/user/<uid> for
+# the Wayland socket. ProtectHome=read-only broke session startup outright.
 NoNewPrivileges=false
 ProtectSystem=strict
-ProtectHome=read-only
 ReadWritePaths=/run /tmp /home
+
+# Note there is deliberately no write access to /etc here: the TLS keypair is
+# created at package install time (the RPM's %post runs
+# "termland-server --generate-cert"), so the daemon only ever reads it. If it
+# is ever missing, regenerate with that same command rather than loosening
+# the sandbox.
 PrivateTmp=true
+
+# Session registry + compositor logs. These used to land in /run/user/0,
+# which logind creates only for a real root login and removes when the last
+# one ends — deleting live state under a running service. RuntimeDirectory
+# gives us a dir that is ours unconditionally; Preserve=yes keeps detached
+# sessions trackable across a server restart (they outlive it by design),
+# while still clearing on reboot.
+RuntimeDirectory=termland
+RuntimeDirectoryPreserve=yes
+Environment=XDG_RUNTIME_DIR=/run/termland
 
 # Allow binding to privileged ports if needed
 AmbientCapabilities=CAP_NET_BIND_SERVICE

--- a/packaging/termland-server.spec
+++ b/packaging/termland-server.spec
@@ -144,6 +144,12 @@ install -Dm644 packaging/termland.pam %{buildroot}%{_sysconfdir}/pam.d/termland
 # SSH subsystem drop-in (sshd_config.d)
 install -Dm644 packaging/50-termland.conf %{buildroot}%{_sysconfdir}/ssh/sshd_config.d/50-termland.conf
 
+# TLS keypair directory. Owned by the package (0700 root:root) so the private
+# key is never world-readable, and so the service's ReadWritePaths= entry for
+# it resolves on a fresh install. Left empty: the cert is generated on first
+# start, or provisioned here out of band.
+install -dm700 %{buildroot}%{_sysconfdir}/pki/termland
+
 # Shell completions
 install -Dm644 termland-server.bash %{buildroot}%{_datadir}/bash-completion/completions/termland-server
 install -Dm644 _termland-server     %{buildroot}%{_datadir}/zsh/site-functions/_termland-server
@@ -151,6 +157,20 @@ install -Dm644 termland-server.fish %{buildroot}%{_datadir}/fish/vendor_completi
 
 %post
 %systemd_post termland-server.service
+
+# Generate the self-signed TLS keypair here rather than from the service:
+# termland-server.service runs under ProtectSystem=strict and so cannot write
+# /etc/pki itself. Idempotent, and guarded so an existing keypair is never
+# replaced — an upgrade must not change the fingerprint clients have pinned.
+# Never fail the transaction over this; the server can still be pointed at a
+# keypair via --tls-cert/--tls-key.
+if [ ! -s %{_sysconfdir}/pki/termland/cert.pem ] || [ ! -s %{_sysconfdir}/pki/termland/key.pem ]; then
+    if ! %{_bindir}/termland-server --generate-cert >/dev/null 2>&1; then
+        echo "  Note: could not generate a TLS keypair in %{_sysconfdir}/pki/termland."
+        echo "  Run 'termland-server --generate-cert' as root, or provision"
+        echo "  cert.pem/key.pem there yourself, before starting the service."
+    fi
+fi
 
 # Hint about setup
 echo ""
@@ -181,6 +201,7 @@ echo ""
 %config(noreplace) %{_sysconfdir}/sysconfig/termland-server
 %config(noreplace) %{_sysconfdir}/pam.d/termland
 %config(noreplace) %{_sysconfdir}/ssh/sshd_config.d/50-termland.conf
+%attr(0700,root,root) %dir %{_sysconfdir}/pki/termland
 %{_datadir}/bash-completion/completions/termland-server
 %{_datadir}/zsh/site-functions/_termland-server
 %{_datadir}/fish/vendor_completions.d/termland-server.fish


### PR DESCRIPTION
Closes #2. Closes #3. Closes #8.

Three separate reports, one root cause.

## The cause

`packaging/termland-server.service` sets `ProtectHome=read-only`. Per `systemd.exec(5)`:

> If set to "read-only", the three directories are made read-only instead … the directories `/home/`, `/root`, and **`/run/user`**

Those last two are exactly what the server writes.

| Issue | Symptom | Why |
|---|---|---|
| #2 | First-run cert generation fails | Certs default to `dirs::config_dir()/termland`, which for `User=root` is `/root/.config/termland` — read-only |
| #3 | `labwc <defunct>`, no contact | `/run/user` read-only, so an isolated session cannot create its runtime dir for the Wayland socket |
| #8 | `open log …: No such file or directory` | Same block, misreported — see below |

`ReadWritePaths=/run` did not rescue `/run/user`. Same man page:

> for each mount point write access is granted only if the mount point itself and the file system superblock backing it are not marked read-only

`/run/user/<uid>` is its own mount point, so `ReadWritePaths=/run` does not reach into it. `/root` was never listed at all.

@hmmsjan diagnosed this correctly in #3 — *"the hardening prevents socket creation"* — and @Arragon5xpwm's `sudo termland-server --tls` workaround in #2 works precisely because it writes the cert **outside** the sandbox, after which the read-only mount is fine for reading it back.

The directive was also wrong for this workload regardless. The sandbox is inherited by every process the service spawns, which here means entire user desktop sessions — it made remote users' own home directories read-only.

## Why #8 reported the wrong thing

`transport.rs` had `let _ = crate::registry::ensure_dir();`. The real `EROFS` was discarded, the session continued, and it died later with a bare `ENOENT` from the compositor's log `open` — naming the symptom and hiding the cause. That error is now propagated.

## Changes

- **Drop `ProtectHome`**, with a comment on why it cannot come back. `ProtectSystem=strict` stays and the daemon still has **no write access to `/etc`**.
- **Certs move to `/etc/pki/termland/`** for root (`~/.config/termland/` stays for unprivileged and SSH-subsystem use). An existing keypair at the old path is still used, with a warning, rather than silently regenerated — anyone who applied the #2 workaround would otherwise get a new fingerprint under clients that already pinned the old one.
- **Generation moves to the RPM's `%post`** via a new `--generate-cert` flag, following mod_ssl's `httpd-ssl-gencerts` pattern. The flag reuses the real generation path, so SANs and the `0600` key mode cannot drift from a shell reimplementation, and it doubles as the documented recovery command.
- **`RuntimeDirectory=termland` replaces `/run/user/<uid>`** for the session registry and compositor logs. logind creates `/run/user/0` only for a real root login and removes it when the last one ends, deleting live state under a running service. `RuntimeDirectoryPreserve=yes` keeps detached sessions trackable across a server restart, which they outlive by design.

## ⚠️ Upgrade note

Changing `XDG_RUNTIME_DIR` means **detached sessions created by a pre-upgrade server are invisible to the new one.** Their compositors keep running, orphaned, and need killing by hand. Close sessions before upgrading. This only affects hosts where the service currently starts at all, which this bug makes a small set.

Also note `/etc/sysconfig/termland-server` is `%config(noreplace)`, so the documentation improvements there reach fresh installs only.

## Verification

- `cargo test -p termland-server` — 14 pass
- `systemd-analyze verify` — clean (only complaint is the binary not being installed on the build host)
- `rpmspec -P` parses; the expanded `%post` passes `bash -n`
- `--generate-cert` exercised end to end: correct SANs, key at `0600`, and a second run leaves the fingerprint untouched
- Full workspace green on this branch in isolation (57 tests)

## Provenance

Written with Claude, per the `Co-Authored-By` trailers and the discussion in #7. The commit message carries the engineering rationale rather than a prompt log — prompts do not reproduce code (model versions drift, and iterative context is not recoverable), whereas the reasoning and the verification commands above can be re-run and checked by anyone.

Every claim here was checked by running it. The `systemd.exec(5)` quotes are from the man page on the build host, not recalled.
