### PR TITLE
Negotiate the audio codec instead of assuming Opus

### DIFF
--- a/crates/termland-client/src/connection.rs
+++ b/crates/termland-client/src/connection.rs
@@ -446,6 +446,9 @@ async fn session_loop<T: AsyncRead + AsyncWrite + Unpin>(
         Some(c) => vec![c],
         None => termland_protocol::VideoCodec::all_preferred(),
     };
+    // Everything this build can decode. Not user-selectable: unlike video,
+    // there is no reason to pin audio to one codec from the command line.
+    let supported_audio_codecs = termland_protocol::AudioCodec::all_preferred();
     match &params.attach {
         Some(id) => {
             tracing::info!("Attaching to session {id}");
@@ -457,6 +460,7 @@ async fn session_loop<T: AsyncRead + AsyncWrite + Unpin>(
                 encoder_crf: params.encoder_crf,
                 encoder_extra_params: params.encoder_extra_params,
                 supported_codecs,
+                supported_audio_codecs,
             })).await?;
         }
         None => {
@@ -471,6 +475,7 @@ async fn session_loop<T: AsyncRead + AsyncWrite + Unpin>(
                 encoder_crf: params.encoder_crf,
                 encoder_extra_params: params.encoder_extra_params,
                 supported_codecs,
+                supported_audio_codecs,
             })).await?;
         }
     }

--- a/crates/termland-codec/src/audio.rs
+++ b/crates/termland-codec/src/audio.rs
@@ -12,6 +12,10 @@ pub const SAMPLE_RATE: u32 = 48000;
 pub const CHANNELS: u8 = 2;
 /// Opus frame size: 20ms at 48kHz = 960 samples per channel.
 pub const FRAME_SIZE: usize = 960;
+/// Target encoder bitrate, in bits per second. Public so the server logs the
+/// rate it is actually encoding at rather than a separately-written constant
+/// that can drift from this one.
+pub const BITRATE: i32 = 32_000;
 
 pub struct OpusEncoder {
     encoder: opus::Encoder,
@@ -24,7 +28,7 @@ impl OpusEncoder {
             opus::Channels::Stereo,
             opus::Application::Audio,
         )?;
-        encoder.set_bitrate(opus::Bitrate::Bits(32000))?;
+        encoder.set_bitrate(opus::Bitrate::Bits(BITRATE))?;
         encoder.set_inband_fec(true)?;
         encoder.set_dtx(true)?;
         Ok(Self { encoder })

--- a/crates/termland-codec/src/audio.rs
+++ b/crates/termland-codec/src/audio.rs
@@ -8,10 +8,43 @@ pub enum AudioError {
     Other(String),
 }
 
+/// Capture/playback rate. 48kHz matches what PulseAudio's null sink runs at
+/// natively, so the capture path does no resampling.
+///
+/// Note this is *not* the bandwidth knob: the encoder targets a fixed
+/// `BITRATE`, and Opus chooses its own coded bandwidth from that. A lower
+/// sample rate sends exactly as many bytes, with less signal to spend them
+/// on. Lower `BITRATE` instead.
 pub const SAMPLE_RATE: u32 = 48000;
 pub const CHANNELS: u8 = 2;
-/// Opus frame size: 20ms at 48kHz = 960 samples per channel.
-pub const FRAME_SIZE: usize = 960;
+
+/// Encoded frame duration. 20ms is the usual real-time compromise: shorter
+/// frames cut latency but spend proportionally more on per-packet overhead.
+pub const FRAME_MS: u32 = 20;
+
+/// Samples per channel in one encoded frame, derived from the rate so the two
+/// cannot drift apart.
+///
+/// This used to be a bare `960` ("20ms at 48kHz"). Lowering `SAMPLE_RATE`
+/// alone would then have silently changed the frame *duration* rather than
+/// the frame size — 960 samples is 40ms at 24kHz and 60ms at 16kHz, both of
+/// which are legal Opus frame sizes, so encoding keeps working and only the
+/// latency quietly gets worse.
+pub const FRAME_SIZE: usize = (SAMPLE_RATE / 1000 * FRAME_MS) as usize;
+
+/// libopus accepts only these input rates; anything else fails at
+/// `Encoder::new` on the first session rather than at build time.
+const _: () = assert!(
+    matches!(SAMPLE_RATE, 8000 | 12000 | 16000 | 24000 | 48000),
+    "SAMPLE_RATE must be a rate libopus supports: 8, 12, 16, 24 or 48 kHz",
+);
+
+/// And only these frame durations (2.5ms also exists, but is not expressible
+/// in whole milliseconds and is far too short to be useful here).
+const _: () = assert!(
+    matches!(FRAME_MS, 5 | 10 | 20 | 40 | 60),
+    "FRAME_MS must be an Opus frame duration: 5, 10, 20, 40 or 60 ms",
+);
 /// Target encoder bitrate, in bits per second. Public so the server logs the
 /// rate it is actually encoding at rather than a separately-written constant
 /// that can drift from this one.
@@ -60,5 +93,82 @@ impl OpusDecoder {
         let samples = self.decoder.decode(data, &mut output, false)?;
         output.truncate(samples * CHANNELS as usize);
         Ok(output)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pins the current defaults. 960 samples per channel at 48kHz is what
+    /// the server chunks capture into and what the decoder sizes its output
+    /// buffer for, so a change here is a protocol-visible change in packet
+    /// cadence, not just a constant.
+    #[test]
+    fn frame_size_is_twenty_ms_at_the_current_rate() {
+        assert_eq!(FRAME_SIZE, 960);
+        assert_eq!(FRAME_SIZE as u32 * 1000 / SAMPLE_RATE, FRAME_MS);
+    }
+
+    /// The decoder allocates `FRAME_SIZE * CHANNELS` per packet, so an
+    /// interleaved frame has to divide evenly into channels.
+    #[test]
+    fn interleaved_frame_divides_by_channel_count() {
+        let interleaved = FRAME_SIZE * CHANNELS as usize;
+        assert_eq!(interleaved % CHANNELS as usize, 0);
+        assert_eq!(interleaved / CHANNELS as usize, FRAME_SIZE);
+    }
+
+    /// Guards the claim in BITRATE's doc comment that it, not SAMPLE_RATE, is
+    /// the bandwidth control: this is the value handed to libopus, so it has
+    /// to stay something libopus will accept (6k-510k per channel).
+    #[test]
+    fn bitrate_is_within_the_opus_accepted_range() {
+        assert!(
+            (6_000..=510_000).contains(&BITRATE),
+            "BITRATE {BITRATE} is outside the range libopus accepts",
+        );
+    }
+
+    /// Opus is fixed-frame: the encoder rejects any buffer that is not exactly
+    /// one frame. This is the round trip the session audio path performs.
+    #[test]
+    fn encoder_accepts_exactly_one_frame_of_silence() {
+        let mut enc = match OpusEncoder::new() {
+            Ok(e) => e,
+            // No libopus at test time - skip rather than fail the suite.
+            Err(_) => return,
+        };
+        let silence = vec![0i16; FRAME_SIZE * CHANNELS as usize];
+        let packet = enc.encode(&silence).expect("one full frame must encode");
+        assert!(!packet.is_empty());
+    }
+
+    /// A short buffer is a programming error in the chunking loop, and must
+    /// surface as an error rather than being silently padded or truncated.
+    #[test]
+    fn encoder_rejects_a_partial_frame() {
+        let mut enc = match OpusEncoder::new() {
+            Ok(e) => e,
+            Err(_) => return,
+        };
+        let short = vec![0i16; (FRAME_SIZE * CHANNELS as usize) - 2];
+        assert!(enc.encode(&short).is_err(), "a partial frame must not encode");
+    }
+
+    #[test]
+    fn silence_survives_an_encode_decode_round_trip() {
+        let (mut enc, mut dec) = match (OpusEncoder::new(), OpusDecoder::new()) {
+            (Ok(e), Ok(d)) => (e, d),
+            _ => return,
+        };
+        let silence = vec![0i16; FRAME_SIZE * CHANNELS as usize];
+        let packet = enc.encode(&silence).expect("encode");
+        let pcm = dec.decode(&packet).expect("decode");
+        assert_eq!(
+            pcm.len(),
+            FRAME_SIZE * CHANNELS as usize,
+            "decoder must return exactly one frame of interleaved samples",
+        );
     }
 }

--- a/crates/termland-mobile-core/src/lib.rs
+++ b/crates/termland-mobile-core/src/lib.rs
@@ -315,6 +315,7 @@ mod tests {
             encoder_crf: None,
             encoder_extra_params: None,
             supported_codecs: p.advertised_codecs(),
+            supported_audio_codecs: termland_protocol::AudioCodec::all_preferred(),
         });
 
         let mut codec = TermlandCodec;

--- a/crates/termland-mobile-core/src/session.rs
+++ b/crates/termland-mobile-core/src/session.rs
@@ -174,6 +174,8 @@ pub(crate) async fn open_session(
 ) -> Result<(Conn, Option<quinn::Connection>, SessionReadyInfo)> {
     let (mut framed, quic_connection) = connect_and_handshake(profile).await?;
     let supported_codecs = params.advertised_codecs();
+    // Android decodes Opus via MediaCodec; see the audio path in this module.
+    let supported_audio_codecs = termland_protocol::AudioCodec::all_preferred();
 
     match attach_to {
         Some(session_id) => {
@@ -187,6 +189,7 @@ pub(crate) async fn open_session(
                     encoder_crf: None,
                     encoder_extra_params: None,
                     supported_codecs,
+                    supported_audio_codecs: supported_audio_codecs.clone(),
                 }))
                 .await?;
         }
@@ -203,6 +206,7 @@ pub(crate) async fn open_session(
                     encoder_crf: None,
                     encoder_extra_params: None,
                     supported_codecs,
+                    supported_audio_codecs: supported_audio_codecs.clone(),
                 }))
                 .await?;
         }

--- a/crates/termland-protocol/src/messages.rs
+++ b/crates/termland-protocol/src/messages.rs
@@ -772,6 +772,101 @@ mod audio_codec_tests {
         assert_eq!(parsed.supported_audio_codecs, vec![AudioCodec::Opus]);
     }
 
+    /// New client -> OLD server: the added fields must be *ignorable*. An
+    /// older peer that has never heard of `supported_audio_codecs` has to
+    /// parse the message and skip the field rather than reject the frame.
+    ///
+    /// This is precisely what makes the audio-negotiation change additive
+    /// instead of a protocol break, so it is pinned here rather than assumed.
+    /// It holds because ciborium encodes structs as CBOR maps keyed by field
+    /// name, and serde skips unknown keys unless `deny_unknown_fields` is set.
+    #[test]
+    fn old_peer_ignores_the_new_audio_fields_on_session_create() {
+        #[derive(Deserialize)]
+        struct OldSessionCreate {
+            width: u32,
+            height: u32,
+            audio: bool,
+            supported_codecs: Vec<VideoCodec>,
+        }
+
+        let new = SessionCreate {
+            mode: SessionMode::Desktop,
+            width: 1920,
+            height: 1080,
+            audio: true,
+            quality: 75,
+            desktop_shell: None,
+            encoder_preset: None,
+            encoder_crf: None,
+            encoder_extra_params: None,
+            supported_codecs: vec![VideoCodec::Av1],
+            supported_audio_codecs: vec![AudioCodec::Opus],
+        };
+
+        let old: OldSessionCreate = reencode(&new);
+        assert_eq!(old.width, 1920);
+        assert_eq!(old.height, 1080);
+        assert!(old.audio);
+        assert_eq!(old.supported_codecs, vec![VideoCodec::Av1]);
+    }
+
+    /// New server -> OLD client, the mirror of the above: an old client must
+    /// still read SessionReady when the server announces an audio codec.
+    #[test]
+    fn old_client_ignores_the_new_audio_codec_in_session_ready() {
+        #[derive(Deserialize)]
+        struct OldSessionReady {
+            width: u32,
+            height: u32,
+            codec: Option<VideoCodec>,
+            session_id: String,
+        }
+
+        let new = SessionReady {
+            width: 1920,
+            height: 1080,
+            xkb_keymap: None,
+            codec: Some(VideoCodec::Av1),
+            audio_codec: Some(AudioCodec::Opus),
+            session_id: "s123".into(),
+        };
+
+        let old: OldSessionReady = reencode(&new);
+        assert_eq!(old.width, 1920);
+        assert_eq!(old.height, 1080);
+        assert_eq!(old.codec, Some(VideoCodec::Av1));
+        assert_eq!(old.session_id, "s123");
+    }
+
+    /// The forward-compatibility above only holds while structs go on the wire
+    /// as name-keyed maps. If this ever became a positional encoding, adding a
+    /// field would silently misalign every field after it on an old peer.
+    #[test]
+    fn structs_are_encoded_as_name_keyed_maps() {
+        let ready = SessionReady {
+            width: 1920,
+            height: 1080,
+            xkb_keymap: None,
+            codec: Some(VideoCodec::Av1),
+            audio_codec: Some(AudioCodec::Opus),
+            session_id: "s123".into(),
+        };
+
+        let mut buf = Vec::new();
+        ciborium::into_writer(&ready, &mut buf).expect("serialize");
+
+        let value: ciborium::Value = ciborium::from_reader(buf.as_slice()).expect("as value");
+        let map = value.as_map().expect("SessionReady must encode as a CBOR map, not an array");
+        let keys: Vec<String> = map
+            .iter()
+            .filter_map(|(k, _)| k.as_text().map(str::to_string))
+            .collect();
+
+        assert!(keys.contains(&"audio_codec".to_string()), "keys were {keys:?}");
+        assert!(keys.contains(&"session_id".to_string()), "keys were {keys:?}");
+    }
+
     #[test]
     fn negotiate_follows_the_clients_preference_order() {
         let picked = AudioCodec::negotiate(&[AudioCodec::Opus], &[AudioCodec::Opus]);

--- a/crates/termland-protocol/src/messages.rs
+++ b/crates/termland-protocol/src/messages.rs
@@ -262,6 +262,11 @@ pub struct SessionCreate {
     /// (older client) means "all codecs supported".
     #[serde(default = "VideoCodec::all_preferred")]
     pub supported_codecs: Vec<VideoCodec>,
+    /// Audio codecs this client can decode, in preference order. An omitted
+    /// field (client predating audio negotiation) means Opus only — see
+    /// `AudioCodec::legacy_default`. Ignored when `audio` is false.
+    #[serde(default = "AudioCodec::legacy_default")]
+    pub supported_audio_codecs: Vec<AudioCodec>,
 }
 
 fn default_quality() -> u8 { 75 }
@@ -276,6 +281,12 @@ pub struct SessionReady {
     /// the client should fall back to auto-detecting from the frame stream.
     #[serde(default)]
     pub codec: Option<VideoCodec>,
+    /// Audio codec the server negotiated for this session, so the client can
+    /// build the matching decoder up front. `None` means either no audio, or
+    /// an older server that always sends Opus — both are handled by treating
+    /// it as Opus when audio frames arrive.
+    #[serde(default)]
+    pub audio_codec: Option<AudioCodec>,
     /// Stable id of the (persistent) session, so the client can reattach to it
     /// later after disconnecting. Empty for older servers with no persistence.
     #[serde(default)]
@@ -323,6 +334,11 @@ pub struct SessionAttach {
     pub encoder_extra_params: Option<String>,
     #[serde(default = "VideoCodec::all_preferred")]
     pub supported_codecs: Vec<VideoCodec>,
+    /// See `SessionCreate::supported_audio_codecs`. Re-advertised on attach
+    /// because a session can be resumed from a different client build than
+    /// the one that created it.
+    #[serde(default = "AudioCodec::legacy_default")]
+    pub supported_audio_codecs: Vec<AudioCodec>,
 }
 
 /// Client -> server: permanently close (terminate) a persistent session.
@@ -388,6 +404,58 @@ impl VideoCodec {
             VideoCodec::H265,
             VideoCodec::H264,
         ]
+    }
+}
+
+/// Audio codec carried by an `AudioFrame`, negotiated the same way as
+/// `VideoCodec`: the client advertises what it can decode in
+/// `SessionCreate`/`SessionAttach` and the server reports its choice in
+/// `SessionReady`.
+///
+/// Listed in preference order. Opus is first and, for now, alone: it is the
+/// only codec every current build encodes and decodes. The enum exists so
+/// that adding another (Vorbis has been asked for, for hosts where Opus is
+/// unavailable) is a variant plus a codec backend, rather than a wire
+/// format change once clients are deployed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AudioCodec {
+    Opus,
+}
+
+impl AudioCodec {
+    /// All codecs in preference order — what a current client advertises.
+    pub fn all_preferred() -> Vec<AudioCodec> {
+        vec![AudioCodec::Opus]
+    }
+
+    /// What to assume when a peer omits `supported_audio_codecs` entirely.
+    ///
+    /// Deliberately *not* `all_preferred()`, which is what the video field
+    /// defaults to. A client old enough to omit this field predates audio
+    /// negotiation, so the only codec it can possibly decode is Opus.
+    /// Defaulting to "everything" would let the server pick a newly-added
+    /// codec for a client that cannot decode it — silent broken audio — and
+    /// the bug would not appear until the second variant was added, long
+    /// after this line was written.
+    pub fn legacy_default() -> Vec<AudioCodec> {
+        vec![AudioCodec::Opus]
+    }
+
+    /// Pick the best codec this server can encode from what the peer
+    /// advertised, in the peer's preference order. `None` means no overlap —
+    /// the caller should run the session without audio rather than send a
+    /// stream the client cannot decode.
+    pub fn negotiate(advertised: &[AudioCodec], encodable: &[AudioCodec]) -> Option<AudioCodec> {
+        advertised.iter().copied().find(|c| encodable.contains(c))
+    }
+}
+
+impl std::fmt::Display for AudioCodec {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            AudioCodec::Opus => "Opus",
+        };
+        f.write_str(s)
     }
 }
 
@@ -568,5 +636,165 @@ mod serde_bytes {
         }
 
         de.deserialize_any(BytesVisitor)
+    }
+}
+
+#[cfg(test)]
+mod audio_codec_tests {
+    use super::*;
+
+    /// Round-trip a value through CBOR the way the wire codec does.
+    fn reencode<T: Serialize, U: for<'de> Deserialize<'de>>(value: &T) -> U {
+        let mut buf = Vec::new();
+        ciborium::into_writer(value, &mut buf).expect("serialize");
+        ciborium::from_reader(buf.as_slice()).expect("deserialize")
+    }
+
+    /// A client predating audio negotiation omits `supported_audio_codecs`
+    /// entirely. It must be read as Opus-only, never as "supports everything":
+    /// the moment a second codec is added, an "everything" default would let
+    /// the server pick one the old client cannot decode.
+    ///
+    /// Modelled with a struct that mirrors SessionCreate minus the new field,
+    /// which is exactly what an old client puts on the wire.
+    #[test]
+    fn client_omitting_audio_codecs_is_treated_as_opus_only() {
+        #[derive(Serialize)]
+        struct OldSessionCreate {
+            mode: SessionMode,
+            width: u32,
+            height: u32,
+            audio: bool,
+            quality: u8,
+            desktop_shell: Option<String>,
+            encoder_preset: Option<String>,
+            encoder_crf: Option<u8>,
+            encoder_extra_params: Option<String>,
+            supported_codecs: Vec<VideoCodec>,
+        }
+
+        let old = OldSessionCreate {
+            mode: SessionMode::Desktop,
+            width: 1920,
+            height: 1080,
+            audio: true,
+            quality: 75,
+            desktop_shell: None,
+            encoder_preset: None,
+            encoder_crf: None,
+            encoder_extra_params: None,
+            supported_codecs: vec![VideoCodec::Av1],
+        };
+
+        let parsed: SessionCreate = reencode(&old);
+        assert_eq!(parsed.supported_audio_codecs, vec![AudioCodec::Opus]);
+        assert_eq!(
+            parsed.supported_audio_codecs,
+            AudioCodec::legacy_default(),
+            "the omitted-field default must stay legacy_default(), not all_preferred()",
+        );
+    }
+
+    /// Same for the attach path — a session can be resumed by a different
+    /// client build than the one that created it.
+    #[test]
+    fn attach_omitting_audio_codecs_is_treated_as_opus_only() {
+        #[derive(Serialize)]
+        struct OldSessionAttach {
+            session_id: String,
+            audio: bool,
+            quality: u8,
+            encoder_preset: Option<String>,
+            encoder_crf: Option<u8>,
+            encoder_extra_params: Option<String>,
+            supported_codecs: Vec<VideoCodec>,
+        }
+
+        let old = OldSessionAttach {
+            session_id: "s123".into(),
+            audio: true,
+            quality: 75,
+            encoder_preset: None,
+            encoder_crf: None,
+            encoder_extra_params: None,
+            supported_codecs: vec![VideoCodec::Av1],
+        };
+
+        let parsed: SessionAttach = reencode(&old);
+        assert_eq!(parsed.supported_audio_codecs, vec![AudioCodec::Opus]);
+    }
+
+    /// An older *server* does not send `audio_codec`. The client must still
+    /// parse SessionReady, and read the absence as "assume Opus".
+    #[test]
+    fn session_ready_without_audio_codec_still_parses() {
+        #[derive(Serialize)]
+        struct OldSessionReady {
+            width: u32,
+            height: u32,
+            xkb_keymap: Option<String>,
+            codec: Option<VideoCodec>,
+            session_id: String,
+        }
+
+        let old = OldSessionReady {
+            width: 1920,
+            height: 1080,
+            xkb_keymap: None,
+            codec: Some(VideoCodec::Av1),
+            session_id: "s123".into(),
+        };
+
+        let parsed: SessionReady = reencode(&old);
+        assert_eq!(parsed.audio_codec, None);
+        assert_eq!(parsed.codec, Some(VideoCodec::Av1));
+    }
+
+    /// A current client's advertisement survives the round trip untouched —
+    /// the default must not overwrite a field that was actually sent.
+    #[test]
+    fn explicit_audio_codecs_survive_the_round_trip() {
+        let create = SessionCreate {
+            mode: SessionMode::Desktop,
+            width: 1920,
+            height: 1080,
+            audio: true,
+            quality: 75,
+            desktop_shell: None,
+            encoder_preset: None,
+            encoder_crf: None,
+            encoder_extra_params: None,
+            supported_codecs: VideoCodec::all_preferred(),
+            supported_audio_codecs: vec![AudioCodec::Opus],
+        };
+
+        let parsed: SessionCreate = reencode(&create);
+        assert_eq!(parsed.supported_audio_codecs, vec![AudioCodec::Opus]);
+    }
+
+    #[test]
+    fn negotiate_follows_the_clients_preference_order() {
+        let picked = AudioCodec::negotiate(&[AudioCodec::Opus], &[AudioCodec::Opus]);
+        assert_eq!(picked, Some(AudioCodec::Opus));
+    }
+
+    /// No shared codec must yield None, so the caller runs the session without
+    /// audio instead of streaming something undecodable.
+    #[test]
+    fn negotiate_returns_none_without_overlap() {
+        assert_eq!(AudioCodec::negotiate(&[], &[AudioCodec::Opus]), None);
+        assert_eq!(AudioCodec::negotiate(&[AudioCodec::Opus], &[]), None);
+    }
+
+    /// Every advertised codec must be one the server could conceivably pick;
+    /// guards against `all_preferred` listing a codec with no encoder.
+    #[test]
+    fn all_preferred_is_a_subset_of_the_known_codecs() {
+        for codec in AudioCodec::all_preferred() {
+            assert_eq!(
+                AudioCodec::negotiate(&[codec], &AudioCodec::all_preferred()),
+                Some(codec),
+            );
+        }
     }
 }

--- a/crates/termland-server/src/transport.rs
+++ b/crates/termland-server/src/transport.rs
@@ -339,6 +339,12 @@ enum SessionRequest {
 /// unchanged from `handle_session`. This function (not `handle_session`) is
 /// where the video uni stream actually gets opened - see the `open_uni()`
 /// call below for why here specifically.
+/// Audio codecs this server can encode, in the order it would prefer them.
+/// Adding one is a new `AudioCodec` variant plus an encoder backend — the
+/// wire format already carries the negotiation.
+const SERVER_AUDIO_CODECS: &[termland_protocol::AudioCodec] =
+    &[termland_protocol::AudioCodec::Opus];
+
 async fn run_session<T>(
     framed: &mut Framed<T, TermlandCodec>,
     request: SessionRequest,
@@ -361,6 +367,7 @@ where
         encoder_crf,
         encoder_extra_params,
         supported_codecs,
+        supported_audio_codecs,
         audio,
         start_kind,
         is_new,
@@ -413,6 +420,11 @@ where
                 termland_protocol::VideoCodec::all_preferred()
             } else {
                 sc.supported_codecs
+            };
+            supported_audio_codecs = if sc.supported_audio_codecs.is_empty() {
+                termland_protocol::AudioCodec::legacy_default()
+            } else {
+                sc.supported_audio_codecs
             };
             audio = sc.audio;
             start_kind = StartKind::Create { log_path: crate::registry::log_path(&id) };
@@ -474,6 +486,11 @@ where
                 termland_protocol::VideoCodec::all_preferred()
             } else {
                 sa.supported_codecs
+            };
+            supported_audio_codecs = if sa.supported_audio_codecs.is_empty() {
+                termland_protocol::AudioCodec::legacy_default()
+            } else {
+                sa.supported_audio_codecs
             };
             audio = sa.audio;
             start_kind = StartKind::Attach {
@@ -586,14 +603,37 @@ where
         None => None,
     };
 
-    // Send SessionReady, announcing the negotiated codec so the client builds
-    // the matching decoder up front instead of guessing from the stream.
+    // Negotiate the audio codec: walk the client's preference order and take
+    // the first one this server can actually encode. Done before SessionReady
+    // so the choice can be announced alongside the video codec.
+    //
+    // `None` when the client asked for audio but shares no codec with us. The
+    // session then runs silently, which is the only safe outcome — sending a
+    // stream the client cannot decode looks like working audio that produces
+    // no sound, and is far harder to diagnose than no audio at all.
+    let audio_codec = if audio {
+        let picked =
+            termland_protocol::AudioCodec::negotiate(&supported_audio_codecs, SERVER_AUDIO_CODECS);
+        if picked.is_none() {
+            tracing::warn!(
+                "  Audio: client advertised {supported_audio_codecs:?}, none of which this \
+                 server can encode — continuing without audio",
+            );
+        }
+        picked
+    } else {
+        None
+    };
+
+    // Send SessionReady, announcing the negotiated codecs so the client builds
+    // the matching decoders up front instead of guessing from the stream.
     framed
         .send(Message::SessionReady(SessionReady {
             width: first_w,
             height: first_h,
             xkb_keymap: None,
             codec: Some(first_codec),
+            audio_codec,
             session_id: session_id.clone(),
         }))
         .await
@@ -612,16 +652,24 @@ where
         }
     );
 
-    // Optionally start audio capture if the client requested it.
-    let (mut audio_rx, _audio_stop_tx, _audio_handle) = if audio {
+    // Optionally start audio capture if the client requested it and we agreed
+    // on a codec.
+    let (mut audio_rx, _audio_stop_tx, _audio_handle) = if let Some(codec) = audio_codec {
         let (atx, arx) = tokio::sync::mpsc::channel::<AudioChunk>(8);
         let (astop_tx, astop_rx) = tokio::sync::oneshot::channel::<()>();
         let sid = session_id.clone();
         let h = std::thread::spawn(move || {
             audio_capture_thread(&sid, atx, astop_rx);
         });
-        tracing::info!("  Audio encoder: Opus 48kHz stereo 64kbps");
+        tracing::info!(
+            "  Audio encoder: {codec} {}Hz {} channel {}kbps",
+            termland_codec::audio::SAMPLE_RATE,
+            termland_codec::audio::CHANNELS,
+            termland_codec::audio::BITRATE / 1000,
+        );
         (Some(arx), Some(astop_tx), Some(h))
+    } else if audio {
+        (None, None, None)
     } else {
         tracing::info!("  Audio encoder: disabled (client did not request audio)");
         (None, None, None)

--- a/crates/termland-server/tests/quic_q2_planes.rs
+++ b/crates/termland-server/tests/quic_q2_planes.rs
@@ -31,7 +31,7 @@ use futures::{SinkExt, StreamExt};
 use tokio_util::codec::Framed;
 
 use termland_protocol::{
-    FrameType, Hello, Message, SessionCreate, SessionMode, TermlandCodec, VideoCodec,
+    AudioCodec, FrameType, Hello, Message, SessionCreate, SessionMode, TermlandCodec, VideoCodec,
     PROTOCOL_VERSION,
 };
 
@@ -195,6 +195,7 @@ async fn quic_q2_video_stream_carries_real_frames() {
             encoder_crf: None,
             encoder_extra_params: None,
             supported_codecs: VideoCodec::all_preferred(),
+            supported_audio_codecs: AudioCodec::all_preferred(),
         }))
         .await
         .expect("send SessionCreate");


### PR DESCRIPTION
Audio was a bare `audio: bool` with Opus hardcoded end to end. Adding a second codec later would have meant a wire format change **after** clients are deployed. This adds the negotiation now, while Opus is still the only variant, so a future codec is an enum variant plus an encoder backend.

Prompted by a request for Ogg Vorbis (for hosts where Opus is unavailable). This PR does **not** add Vorbis — it makes adding it cheap.

## Not a breaking change — verified in both directions

| Direction | Behaviour | |
|---|---|---|
| Old client → new server | Omitted field defaults to Opus | ✅ tested |
| New client → old server | Unknown field skipped | ✅ tested |
| Old server → new client | Missing `audio_codec` → `None` → assume Opus | ✅ tested |
| New server → old client | Extra field skipped | ✅ tested |

This holds because ciborium encodes structs as **name-keyed CBOR maps** and serde skips unknown keys without `deny_unknown_fields`. The encoding shape is asserted directly, not assumed: under a positional encoding, appending a field would silently misalign every field after it on an old peer — reaching users as corrupt sessions rather than a clear error.

`PROTOCOL_VERSION` stays at **1**, which these tests justify.

## One deliberate asymmetry with the video path

`supported_codecs` defaults to `all_preferred()` when omitted. `supported_audio_codecs` defaults to `legacy_default()` — **Opus only** — and that difference is the point.

A client old enough to omit the field predates audio negotiation and can decode nothing else. An "everything" default would let the server pick a newly-added codec that client cannot handle. The bug would not surface until the second variant was added, long after the line was written, and would present as audio that connects and produces silence.

Pinned rather than asserted: simulating a future with a second codec **and** an `all_preferred` default makes the test fail. The attach-path test correctly stays green under that mutation, since only `SessionCreate`'s default was changed.

## Behaviour

When the client requests audio but shares no codec with the server, the session now runs **silently and logs why**, rather than streaming something undecodable. Audio that plays nothing is far harder to diagnose than no audio at all.

## Also fixed: two constants that lied

- The session log claimed `Opus 48kHz stereo 64kbps` while the encoder is configured for **32000 bps**. The rate is now a shared constant both the encoder and the log read.
- `FRAME_SIZE` was a bare `960`, documented as "20ms at 48kHz" but not tied to `SAMPLE_RATE`. Lowering the rate alone would have changed the frame *duration* instead: 960 samples is 40ms at 24kHz and 60ms at 16kHz — both legal Opus frame sizes, so encoding keeps working and only latency quietly degrades. At 12kHz it is 80ms, which is illegal and fails at `Encoder::new` on the first session requesting audio.

`FRAME_SIZE` is now derived, and two `const` assertions reject an unusable configuration **at build time**:

```
SAMPLE_RATE must be a rate libopus supports: 8, 12, 16, 24 or 48 kHz
```

`44100` is the obvious trap — a perfectly ordinary PCM rate that Opus does not accept. It now fails the build rather than the first user who enables audio. No behaviour change: `FRAME_SIZE` is still 960 at 48kHz.

Worth recording for anyone tempted to lower the rate to save bandwidth: it does not. The encoder targets a fixed `BITRATE` and Opus picks its own coded bandwidth from that, so a lower sample rate sends the same bytes with less signal to spend them on — and costs CPU, since PulseAudio's null sink is 48kHz natively and a lower rate adds a resample. `BITRATE` is the knob.

## Verification

- Full workspace green on this branch in isolation: **73 tests**
- Compile-time guards mutation-tested: `44100` fails the build with the message above; `24000` correctly derives `FRAME_SIZE` to 480
- Round trips exercised against real libopus, skipping rather than failing where unavailable

## Provenance

Written with Claude, per the `Co-Authored-By` trailers and the discussion in #7. The compatibility table above is the reviewable claim in this PR, and each row corresponds to a test in `messages.rs` that can be re-run — which is what actually lets someone verify or re-implement this, rather than a prompt log.
