### PR TITLE
Stop leaking desktop sessions and hijacking the default audio sink

### DIFF
--- a/crates/termland-compositor/src/backend.rs
+++ b/crates/termland-compositor/src/backend.rs
@@ -212,6 +212,7 @@ pub fn detached_compositor_command(
     height: u32,
     log_path: &Path,
     run_as: Option<&str>,
+    audio_sink: Option<&str>,
 ) -> Result<(Command, PathBuf), CompositorError> {
     let log = std::fs::OpenOptions::new()
         .create(true)
@@ -231,7 +232,17 @@ pub fn detached_compositor_command(
         .env("WLR_BACKENDS", "headless")
         .env("WLR_HEADLESS_OUTPUTS", "1")
         .env("WLR_HEADLESS_OUTPUT_MODE", format!("{width}x{height}"))
-        .env("XDG_SESSION_TYPE", "wayland")
+        .env("XDG_SESSION_TYPE", "wayland");
+
+    // Route this session's audio to its own sink, for this process tree only.
+    // Setting the *global* default sink instead would silence the local
+    // desktop for as long as the session runs, and strand it on a dead sink
+    // if the server exits without unloading the null sink.
+    if let Some(sink) = audio_sink {
+        cmd.env("PULSE_SINK", sink);
+    }
+
+    cmd
         .stdin(Stdio::null())
         .stdout(Stdio::from(log))
         .stderr(Stdio::from(log_err));

--- a/crates/termland-compositor/src/backend/cage.rs
+++ b/crates/termland-compositor/src/backend/cage.rs
@@ -18,6 +18,7 @@ pub fn launch_detached(
     app_args: &[String],
     log_path: &Path,
     run_as: Option<&str>,
+    audio_sink: Option<&str>,
 ) -> Result<DetachedBackend, CompositorError> {
     let inner = if app_args.is_empty() {
         app_cmd.to_string()
@@ -26,7 +27,7 @@ pub fn launch_detached(
     };
     tracing::info!("Launching detached cage: {inner} ({width}x{height})");
 
-    let (mut cmd, runtime_dir) = detached_compositor_command("cage", width, height, log_path, run_as)?;
+    let (mut cmd, runtime_dir) = detached_compositor_command("cage", width, height, log_path, run_as, audio_sink)?;
     cmd.arg("-d")
         .arg("--")
         .arg("sh")

--- a/crates/termland-compositor/src/backend/labwc.rs
+++ b/crates/termland-compositor/src/backend/labwc.rs
@@ -19,6 +19,7 @@ pub fn launch_detached(
     shell_cmd: &str,
     log_path: &Path,
     run_as: Option<&str>,
+    audio_sink: Option<&str>,
 ) -> Result<DetachedBackend, CompositorError> {
     tracing::info!("Launching detached labwc: {shell_cmd} ({width}x{height})");
     let config_dir = write_minimal_config(width, height)?;
@@ -26,7 +27,7 @@ pub fn launch_detached(
     let wrapper = socket_wrapper_cmd(shell_cmd);
     let sh_arg = format!("sh -c '{}'", wrapper.replace('\'', r"'\''"));
 
-    let (mut cmd, runtime_dir) = detached_compositor_command("labwc", width, height, log_path, run_as)?;
+    let (mut cmd, runtime_dir) = detached_compositor_command("labwc", width, height, log_path, run_as, audio_sink)?;
     cmd.arg("-C").arg(&config_dir)
         .arg("-S").arg(&sh_arg)
         .env("XCURSOR_THEME", "Adwaita")

--- a/crates/termland-compositor/src/session.rs
+++ b/crates/termland-compositor/src/session.rs
@@ -26,6 +26,16 @@ pub struct CompositorConfig {
     /// For Desktop mode: the startup command to run inside labwc.
     /// If None, we auto-detect a terminal emulator.
     pub desktop_shell: Option<String>,
+    /// PulseAudio sink that applications inside this session should play to,
+    /// exported to the compositor as `PULSE_SINK` and inherited by everything
+    /// it launches. `None` when the session has no audio.
+    ///
+    /// This is deliberately per-process rather than a `pactl set-default-sink`
+    /// call: the default sink is global to the user, so setting it would take
+    /// the audio of the *local* desktop hostage for as long as a remote
+    /// session is running — and leave it pointed at a dead sink if the server
+    /// exits without cleaning up.
+    pub audio_sink: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -93,11 +103,17 @@ impl Compositor {
                     .clone()
                     .unwrap_or_else(detect_desktop_shell);
                 tracing::info!("Desktop shell: {shell}");
-                let d = backend::labwc::launch_detached(config.width, config.height, &shell, log_path, run_as)?;
+                let d = backend::labwc::launch_detached(
+                    config.width, config.height, &shell, log_path, run_as,
+                    config.audio_sink.as_deref(),
+                )?;
                 (d.pid, d.wayland_display, "labwc", d.runtime_dir)
             }
             SessionMode::App { command, args } => {
-                let d = backend::cage::launch_detached(config.width, config.height, command, args, log_path, run_as)?;
+                let d = backend::cage::launch_detached(
+                    config.width, config.height, command, args, log_path, run_as,
+                    config.audio_sink.as_deref(),
+                )?;
                 (d.pid, d.wayland_display, "cage", d.runtime_dir)
             }
         };

--- a/crates/termland-server/src/transport.rs
+++ b/crates/termland-server/src/transport.rs
@@ -339,6 +339,15 @@ enum SessionRequest {
 /// unchanged from `handle_session`. This function (not `handle_session`) is
 /// where the video uni stream actually gets opened - see the `open_uni()`
 /// call below for why here specifically.
+/// PulseAudio sink name for a session's null sink.
+///
+/// Single source of truth: `audio_capture_thread` creates the sink under this
+/// name and the compositor is pointed at it via `PULSE_SINK`, so the two must
+/// agree exactly or session audio silently goes to the wrong place.
+fn session_sink_name(session_id: &str) -> String {
+    format!("termland_{}", session_id.replace('-', "_"))
+}
+
 async fn run_session<T>(
     framed: &mut Framed<T, TermlandCodec>,
     request: SessionRequest,
@@ -501,10 +510,13 @@ where
     // Cloned before the move into capture_thread below: also needed to
     // populate the registry record's `owner` field once the compositor is up.
     let record_owner = run_as.clone();
+    // Only when audio was requested; the sink itself is created by
+    // `audio_capture_thread` once the capture stream opens.
+    let capture_audio_sink = audio.then(|| session_sink_name(&session_id));
     let capture_handle = std::thread::spawn(move || {
         capture_thread(width, height, quality, mode, desktop_shell,
                        encoder_preset, encoder_crf, encoder_extra_params,
-                       capture_codecs, start_kind, run_as,
+                       capture_codecs, start_kind, capture_audio_sink, run_as,
                        overlay_cursor_capture, resize_rx, frame_tx, display_tx, stop_rx);
     });
 
@@ -1006,6 +1018,9 @@ fn capture_thread(
     encoder_extra_params: Option<String>,
     supported_codecs: Vec<termland_protocol::VideoCodec>,
     start_kind: StartKind,
+    // Sink that session applications should play to, exported as
+    // `PULSE_SINK`. `None` when the client did not request audio.
+    audio_sink: Option<String>,
     // The PAM-authenticated username to isolate a freshly-created session's
     // compositor into (session isolation), or `None` when the server is
     // running without `--auth`. Only consulted for `StartKind::Create` - an
@@ -1018,7 +1033,9 @@ fn capture_thread(
     display_tx: tokio::sync::oneshot::Sender<(String, u32, std::path::PathBuf)>,
     mut stop_rx: tokio::sync::oneshot::Receiver<()>,
 ) {
-    let config = termland_compositor::CompositorConfig { width, height, mode, desktop_shell };
+    let config = termland_compositor::CompositorConfig {
+        width, height, mode, desktop_shell, audio_sink,
+    };
     let (mut compositor, comp_pid) = match start_kind {
         StartKind::Create { log_path } => {
             match termland_compositor::Compositor::create(config, &log_path, run_as.as_deref()) {
@@ -1229,7 +1246,7 @@ fn audio_capture_thread(
     audio_tx: tokio::sync::mpsc::Sender<AudioChunk>,
     mut stop_rx: tokio::sync::oneshot::Receiver<()>,
 ) {
-    let sink_name = format!("termland_{}", session_id.replace('-', "_"));
+    let sink_name = session_sink_name(session_id);
     let monitor_source = format!("{sink_name}.monitor");
 
     // Load a null sink so apps in this session have somewhere to output audio.
@@ -1255,10 +1272,13 @@ fn audio_capture_thread(
         }
     };
 
-    // Set this sink as the default so apps in the session use it.
-    let _ = std::process::Command::new("pactl")
-        .args(["set-default-sink", &sink_name])
-        .output();
+    // NOTE: deliberately no `pactl set-default-sink` here. The default sink is
+    // global to the user, so pointing it at this session's null sink silences
+    // the local desktop for as long as the session runs, and leaves it aimed
+    // at a dead sink if the server exits without unloading the module (a kill
+    // -9, a crash, or a test harness reaping the child). Session applications
+    // are routed with `PULSE_SINK` on the compositor process instead — see
+    // `CompositorConfig::audio_sink` — which affects only that process tree.
 
     // Open a PulseAudio recording stream from the monitor source.
     let spec = pulse::sample::Spec {

--- a/crates/termland-server/tests/quic_handshake.rs
+++ b/crates/termland-server/tests/quic_handshake.rs
@@ -77,10 +77,16 @@ const ALPN: &[u8] = b"termland/1";
 async fn quic_hello_hello_ack_round_trip() {
     let port: u16 = 27867;
 
+    // An explicit --port matters: without it the spawned server falls back
+    // to the default 7867, which collides with any termland-server the
+    // developer already has running — a normal state to be in — and the
+    // bind failure kills the child before QUIC ever starts, surfacing as an
+    // unrelated-looking handshake timeout.
     let bin = env!("CARGO_BIN_EXE_termland-server");
     eprintln!("[test] spawning {bin} --quic --quic-port {port}");
     let child = Command::new(bin)
-        .args(["--bind", "127.0.0.1", "--quic", "--quic-port", &port.to_string()])
+        .args(["--bind", "127.0.0.1", "--port", "27866",
+               "--quic", "--quic-port", &port.to_string()])
         .env("RUST_LOG", "info")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/termland-server/tests/quic_q2_planes.rs
+++ b/crates/termland-server/tests/quic_q2_planes.rs
@@ -189,10 +189,16 @@ fn decode_video_codec_tag(tag: u8) -> Option<VideoCodec> {
 async fn quic_q2_video_stream_carries_real_frames() {
     let port: u16 = 27868;
 
+    // An explicit --port matters: without it the spawned server falls back
+    // to the default 7867, which collides with any termland-server the
+    // developer already has running — a normal state to be in — and the
+    // bind failure kills the child before QUIC ever starts, surfacing as an
+    // unrelated-looking handshake timeout.
     let bin = env!("CARGO_BIN_EXE_termland-server");
     eprintln!("[test] spawning {bin} --quic --quic-port {port}");
     let child = Command::new(bin)
-        .args(["--bind", "127.0.0.1", "--quic", "--quic-port", &port.to_string()])
+        .args(["--bind", "127.0.0.1", "--port", "27865",
+               "--quic", "--quic-port", &port.to_string()])
         .env("RUST_LOG", "info")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())

--- a/crates/termland-server/tests/quic_q2_planes.rs
+++ b/crates/termland-server/tests/quic_q2_planes.rs
@@ -43,6 +43,94 @@ impl Drop for ChildGuard {
     }
 }
 
+/// Closes the persistent session this test creates, even if an assertion
+/// panics part-way through.
+///
+/// Killing the server child is **not** sufficient. Compositors are
+/// deliberately `setsid`-detached so they outlive the server process — that
+/// is the whole point of resumable sessions — so a test that only kills the
+/// server strands a full desktop session (labwc + the configured shell, here
+/// `plasmashell` and a terminal) on the machine for every run, forever.
+///
+/// Teardown goes through the server binary's own `--close-session` rather
+/// than the wire protocol for two reasons: `Drop` is synchronous, so it
+/// cannot await a `SessionClose` send, and it must still work on the unwind
+/// path where the connection may already be gone. Reading the registry
+/// directly is exactly what `--close-session` does, and it works whether or
+/// not the server child is still alive.
+struct SessionGuard {
+    bin: &'static str,
+    session_id: Option<String>,
+}
+
+impl SessionGuard {
+    fn new(bin: &'static str) -> Self {
+        Self { bin, session_id: None }
+    }
+
+    /// Start tracking the session announced in `SessionReady`. An empty id
+    /// means the server did not create a persistent session, so there is
+    /// nothing to clean up.
+    fn track(&mut self, session_id: &str) {
+        if !session_id.is_empty() {
+            self.session_id = Some(session_id.to_string());
+        }
+    }
+}
+
+impl SessionGuard {
+    /// Unload the session's PulseAudio null sink.
+    ///
+    /// The server creates it and unloads it on graceful shutdown, but this
+    /// harness kills the child, so that cleanup never runs and the sink is
+    /// left behind with nothing alive that owns it. Best-effort: `pactl` is
+    /// absent on headless CI, and a run with no audio never created one.
+    fn unload_null_sink(id: &str) {
+        let sink = format!("termland_{}", id.replace('-', "_"));
+        let Ok(out) = Command::new("pactl").args(["list", "short", "modules"]).output() else {
+            return;
+        };
+        for line in String::from_utf8_lossy(&out.stdout).lines() {
+            if !line.contains(&format!("sink_name={sink}")) {
+                continue;
+            }
+            if let Some(module_id) = line.split_whitespace().next() {
+                let _ = Command::new("pactl").args(["unload-module", module_id]).output();
+                eprintln!("[test] unloaded null sink {sink} (module {module_id})");
+            }
+        }
+    }
+}
+
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        let Some(id) = self.session_id.take() else {
+            return;
+        };
+        Self::unload_null_sink(&id);
+        match Command::new(self.bin).args(["--close-session", &id]).output() {
+            Ok(out) if out.status.success() => {
+                eprintln!("[test] closed session {id}");
+            }
+            Ok(out) => {
+                // Loud, because the cost of missing this is a stray desktop
+                // session that nothing will ever reap.
+                eprintln!(
+                    "[test] WARNING: failed to close session {id} — it may still be running. \
+                     stderr: {}",
+                    String::from_utf8_lossy(&out.stderr).trim(),
+                );
+            }
+            Err(e) => {
+                eprintln!(
+                    "[test] WARNING: could not run --close-session for {id}: {e}. \
+                     Close it by hand with: termland-server --close-session {id}",
+                );
+            }
+        }
+    }
+}
+
 #[derive(Debug)]
 struct AcceptAnyCert;
 impl rustls::client::danger::ServerCertVerifier for AcceptAnyCert {
@@ -111,6 +199,9 @@ async fn quic_q2_video_stream_carries_real_frames() {
         .spawn()
         .expect("failed to spawn termland-server");
     let mut guard = ChildGuard(child);
+    // Declared after `guard` so it drops *first*: the session is closed while
+    // the server is still up, and before the child is reaped.
+    let mut session_guard = SessionGuard::new(bin);
 
     tokio::time::sleep(std::time::Duration::from_millis(800)).await;
 
@@ -214,6 +305,10 @@ async fn quic_q2_video_stream_carries_real_frames() {
         }
         other => panic!("expected SessionReady, got {other:?}"),
     };
+    // Register for teardown as early as possible — every assertion below this
+    // point can panic, and each one would otherwise leak the session.
+    session_guard.track(&ready.session_id);
+
     let negotiated_codec = ready.codec.expect("server always announces a codec in SessionReady");
 
     // --- Video plane: read one real frame off the Q2 uni stream. ---


### PR DESCRIPTION
Two bugs found while running the test suite repeatedly during other work. They compound: the first strands sessions, the second means those sessions take the machine's audio output with them.

## 1. Sessions hijacked the machine's default audio sink

`audio_capture_thread` created the session's null sink and then ran `pactl set-default-sink` on it.

The default sink is **global to the user**, not scoped to the session. So starting any session with audio silently moved the *local* desktop's audio to a sink only the remote session reads from — and left it pointed at a dead sink if the server exited without unloading the module (`kill -9`, a crash, or a test harness reaping the child). Recovering needed manual `pactl` surgery, with nothing on screen explaining why sound had stopped.

The intent was right — applications *inside* the session should play to the session's sink — but the mechanism was far too broad. They're now routed with `PULSE_SINK` on the compositor process, which the whole session process tree inherits and nothing outside it sees.

`CompositorConfig` gains `audio_sink`, threaded to the labwc and cage launchers and exported in `detached_compositor_command` alongside the other per-session environment. The sink name moves into `session_sink_name()` so the thread that *creates* the sink and the compositor that *plays to* it cannot drift — they must agree exactly or session audio silently goes nowhere.

## 2. `quic_q2_planes` stranded a desktop session per run

The test killed the server child and stopped there. Compositors are deliberately `setsid`-detached so they outlive the server — that's what makes sessions resumable — so killing the server **is not teardown**.

Seventeen runs during unrelated work left seventeen live sessions: 102 processes (labwc + plasmashell + a terminal + dbus, each), and enough capture streams against `pipewire-pulse` that it stopped accepting clients entirely — `pactl` failed outright until they were cleared.

`SessionGuard` closes the session in `Drop`, so it also runs when an assertion panics mid-test — the common case, and the one where a leak is least likely to be noticed. Teardown uses the server binary's own `--close-session` rather than the wire protocol, because `Drop` is synchronous and cannot await a `SessionClose`, and it has to work on the unwind path where the connection may already be gone. It also unloads the null sink, which the server would remove on a graceful exit but cannot when the harness kills it.

## Verification

Measured before and after on a real desktop, not inferred:

| | Before | After |
|---|---|---|
| Sessions left per run | 1 | **0** |
| Stray compositors | accumulating | **0** |
| Leaked null-sink modules | 1 per run | **0** |
| Default sink | **hijacked** | untouched |

The panic path is verified rather than assumed: injecting `panic!()` immediately after session creation makes the test fail, and the session, compositor and null sink are all still cleaned up.

Full workspace green on this branch in isolation (57 tests).

## Why this should land before CI

A CI workflow running `cargo test` would strand a desktop session on the runner for **every job**. This needs to be in first.

## 3. The QUIC tests collided with a running server

Found while testing a build with a server running in another terminal. Both QUIC tests spawned the server with `--quic --quic-port` but **no `--port`**, so its TCP listener fell back to the default **7867** — which any already-running `termland-server` holds. The bind failed, killing the child before QUIC started, and surfaced as:

```
QUIC handshake timed out
```

...which points nowhere near the actual cause. Confirmed as pre-existing by reproducing it on a clean checkout of `main`, which ruled out anything under review.

Both now pass an explicit `--port`, with a comment recording why it isn't optional. Verified by running them *with* a server still holding 7867: they pass; before the change they timed out.

Relevant to #13 — a red build whose message points at QUIC when the real problem is a port conflict is the kind of failure people learn to ignore.

## Known limitation

A server killed with `SIGKILL` still leaves its null sink loaded — nothing runs to unload it. That's now a stray entry in the device list rather than a machine whose audio output has moved, so it degrades gracefully. Sweeping stale sinks at server startup would close it properly, but that needs care not to remove sinks belonging to a live session from another server instance, so it's left for separate work.

## Provenance

Written with Claude, per the `Co-Authored-By` trailers and the discussion in #7. Both bugs were found by running the suite and observing the machine, not by reading code — the before/after table is reproducible with `pactl list short modules`, `--list-sessions`, and `pactl get-default-sink`.

