### PR TITLE
Add CI: build and unit-test on the target distro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,82 @@
+name: CI
+
+# Runs on the target distro rather than ubuntu-latest so the dependency list
+# below can be the same one the RPMs already build against
+# (packaging/*.spec BuildRequires), instead of a hand-translated Debian
+# equivalent that drifts from what actually ships.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  # Fail the build on warnings in our own crates. Vendored dependencies are
+  # not built with this.
+  RUSTFLAGS: -D warnings
+
+jobs:
+  test:
+    name: Build and test
+    runs-on: ubuntu-latest
+    container: fedora:43
+
+    steps:
+      - name: Install build dependencies
+        # Kept in sync with BuildRequires in packaging/termland-server.spec and
+        # packaging/termland-client.spec — this is the union of the two, plus
+        # git, which the checkout action needs inside a container.
+        run: |
+          dnf install -y --setopt=install_weak_deps=False \
+            git \
+            rust cargo \
+            clang-devel \
+            cmake gcc gcc-c++ \
+            perl \
+            ffmpeg-free-devel \
+            opus-devel \
+            pulseaudio-libs-devel \
+            alsa-lib-devel \
+            pam-devel \
+            wayland-devel wayland-protocols-devel
+
+      - uses: actions/checkout@v4
+
+      - name: Cache cargo registry and build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-fedora43-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-fedora43-cargo-
+
+      - name: Show toolchain
+        run: cargo --version && rustc --version
+
+      - name: Build workspace
+        run: cargo build --workspace --locked
+
+      # Unit tests only.
+      #
+      # The integration tests under crates/termland-server/tests/ spawn a real
+      # server, which starts a real Wayland compositor (labwc/cage) and opens a
+      # PulseAudio capture stream. A headless runner has neither, so they would
+      # fail for reasons unrelated to the change under test.
+      #
+      # They are still worth running by hand on a desktop:
+      #     cargo test --workspace
+      # and they now clean up after themselves — see SessionGuard in
+      # quic_q2_planes.rs. Before that fix, running them here would have
+      # stranded a detached desktop session on the runner for every job.
+      - name: Run unit tests
+        run: cargo test --workspace --locked --lib --bins
+
+      - name: Check the RPM specs still parse
+        run: |
+          dnf install -y --setopt=install_weak_deps=False rpm-build
+          rpmspec -P packaging/termland-server.spec > /dev/null
+          rpmspec -P packaging/termland-client.spec > /dev/null


### PR DESCRIPTION
There was no CI in this repo, so nothing checked that a change built or that the tests passed before it reached `main`. That matters more now that #4 and #6 ask for test coverage: without a gate, "were the tests run" depends on whoever opened the PR remembering to. It matters more again once other people can merge — approval shouldn't be the only check.

## Fedora container, not `ubuntu-latest`

The dependency list is the **union of `BuildRequires` from the two RPM specs, verbatim**, rather than a hand-translated Debian equivalent that would drift from what actually ships. It also means CI builds against the distro the project targets and packages for.

## Unit tests only, on purpose

`--lib --bins`. The integration tests under `crates/termland-server/tests/` spawn a real server, which starts a real Wayland compositor and opens a PulseAudio capture stream. A headless runner has neither, so they'd fail for reasons unrelated to the change under test — the worst kind of CI, the sort people learn to ignore.

The workflow comment says this outright and points at running them by hand on a desktop with `cargo test --workspace`.

## ⚠️ Merge #12 first

Before that fix, every CI job would have **stranded a detached desktop session on the runner** — compositors are `setsid`-detached and survive the server being killed. Merging this first would leak one per job.

## What was verified before committing

| Check | Result |
|---|---|
| YAML parses | ✅ |
| `--locked` satisfied (lockfile current) | ✅ |
| Workspace builds under `RUSTFLAGS=-D warnings` | ✅ clean |
| CI's exact test command under `-D warnings` | ✅ 55 tests, no warnings |

`-D warnings` is only enabled because the tree passes it *today*, checked rather than assumed — a warning gate that fails on arrival trains people to ignore CI.

The job also re-parses both RPM specs, which catches the packaging-breakage class that otherwise only shows up at release time.

## What is deliberately not here

No `rustfmt` or `clippy` gate. Neither component is installed on the machine this was written on, so I could not confirm the tree passes them, and adding an unverified gate would red-light the repo on its first run. Both are worth adding as a follow-up by someone who can check the result first.

## Honest limitation

I could not execute a GitHub Actions run locally, so the container build itself is unproven — the dependency names are the strongest available evidence (they build the shipping RPMs) but the first run may still need a tweak. Everything that *could* be checked locally, was.

## Provenance

Written with Claude, per the `Co-Authored-By` trailer and the discussion in #7.
