### PR TITLE
Enumerate session windows and send them to the client

### DIFF
--- a/crates/termland-client/src/connection.rs
+++ b/crates/termland-client/src/connection.rs
@@ -20,6 +20,10 @@ pub enum ServerEvent {
     /// Carries no position - see the note on `RemoteCursor` in display.rs for
     /// why position stays purely locally-tracked.
     CursorUpdate(CursorUpdate),
+    /// The set of windows open inside the session changed. Sent by the
+    /// server on change only, and always the complete list — a window absent
+    /// from a later one has closed. Drives the window list overlay.
+    WindowList(Vec<termland_protocol::WindowInfo>),
     #[allow(dead_code)]
     Pong(Pong),
     /// The server explicitly ended the session: it sent us a `SessionEnd`
@@ -583,6 +587,9 @@ async fn session_loop<T: AsyncRead + AsyncWrite + Unpin>(
                     Some(Ok(Message::CursorUpdate(cu))) => {
                         bytes_since_report += cu.image_rgba.len() as u64;
                         let _ = server_tx.send(ServerEvent::CursorUpdate(cu));
+                    }
+                    Some(Ok(Message::WindowList(list))) => {
+                        let _ = server_tx.send(ServerEvent::WindowList(list.windows));
                     }
                     Some(Ok(Message::ClipboardData(cp))) => {
                         tracing::debug!("Clipboard received ({} bytes)", cp.data.len());

--- a/crates/termland-client/src/display.rs
+++ b/crates/termland-client/src/display.rs
@@ -157,6 +157,10 @@ struct App {
     bar_layout: Option<BarLayout>,
     /// Menubar item currently under the mouse (for hover highlight).
     bar_hovered: Option<BarItem>,
+    /// Windows open inside the session, as last reported by the server.
+    /// Replaced wholesale on each update: the server always sends the complete
+    /// list, never a delta.
+    session_windows: Vec<termland_protocol::WindowInfo>,
     /// Is the menubar currently visible? Off by default — toggle with F10.
     bar_visible: bool,
     /// Is the window currently fullscreen? (also hides the menubar)
@@ -198,6 +202,7 @@ impl App {
             cursor_win_x: 0.0, cursor_win_y: 0.0,
             cursor_in_window: false,
             remote_cursor: RemoteCursor::default(),
+            session_windows: Vec::new(),
             data_rate: 0,
             last_title: String::new(),
             bar_layout: None,
@@ -295,6 +300,9 @@ impl App {
             BarItem::ClientCursor => {
                 self.menu.client_cursor = !self.menu.client_cursor;
                 self.send_cmd(ClientCommand::SetCursorInFrame(!self.menu.client_cursor));
+            }
+            BarItem::Windows => {
+                self.menu.show_windows = !self.menu.show_windows;
             }
             BarItem::Fullscreen => {
                 self.toggle_fullscreen();
@@ -397,6 +405,9 @@ impl App {
                 }
                 ServerEvent::DataRate { bytes_per_sec } => {
                     self.data_rate = bytes_per_sec;
+                }
+                ServerEvent::WindowList(windows) => {
+                    self.session_windows = windows;
                 }
                 ServerEvent::CursorUpdate(cu) => {
                     self.remote_cursor = RemoteCursor {
@@ -535,14 +546,31 @@ impl App {
                     &mut buffer, ww_nz.get(), wh_nz.get(),
                     self.menu.show_data_rate,
                     self.menu.client_cursor,
+                    self.menu.show_windows,
                     self.fullscreen,
                     self.data_rate,
+                    self.session_windows.len(),
                     self.bar_hovered,
                 );
                 self.bar_layout = Some(layout);
             } else {
                 self.bar_layout = None;
                 self.bar_hovered = None;
+            }
+
+            // Window list panel. Sits under the menubar when that is showing,
+            // otherwise at the top of the screen.
+            if self.menu.show_windows {
+                let top = if self.bar_visible && !self.fullscreen {
+                    overlay::MENUBAR_HEIGHT
+                } else {
+                    0
+                };
+                overlay::draw_window_list(
+                    &mut buffer, ww_nz.get(), wh_nz.get(),
+                    &self.session_windows,
+                    top,
+                );
             }
 
             // Reconnect status banner: drawn over the frozen last frame

--- a/crates/termland-client/src/overlay.rs
+++ b/crates/termland-client/src/overlay.rs
@@ -21,6 +21,10 @@ const CURSOR_FILL: u32    = 0xFFFFFF;
 pub struct MenuState {
     pub show_data_rate: bool,
     pub client_cursor: bool,
+    /// Show the session's window list. Off by default: it covers part of the
+    /// remote screen, so it is something you open to look at, not a permanent
+    /// fixture.
+    pub show_windows: bool,
 }
 
 impl MenuState {
@@ -28,6 +32,7 @@ impl MenuState {
         Self {
             show_data_rate: true,
             client_cursor: true,
+            show_windows: false,
         }
     }
 }
@@ -356,6 +361,7 @@ const BAR_ON_FG: u32    = 0xA6E3A1; // green for enabled toggles
 pub enum BarItem {
     DataRate,
     ClientCursor,
+    Windows,
     Fullscreen,
     Quit,
 }
@@ -364,12 +370,13 @@ pub enum BarItem {
 pub const BAR_ITEMS: &[BarItem] = &[
     BarItem::DataRate,
     BarItem::ClientCursor,
+    BarItem::Windows,
     BarItem::Fullscreen,
     BarItem::Quit,
 ];
 
 impl BarItem {
-    fn label(&self, show_data_rate: bool, client_cursor: bool, fullscreen: bool, rate: u64) -> String {
+    fn label(&self, show_data_rate: bool, client_cursor: bool, show_windows: bool, fullscreen: bool, rate: u64, window_count: usize) -> String {
         match self {
             Self::DataRate => {
                 if show_data_rate {
@@ -384,6 +391,10 @@ impl BarItem {
                 } else {
                     " [ ] Local cursor ".to_string()
                 }
+            }
+            Self::Windows => {
+                let mark = if show_windows { "x" } else { " " };
+                format!(" [{mark}] Windows ({window_count}) ")
             }
             Self::Fullscreen => {
                 if fullscreen {
@@ -410,8 +421,10 @@ pub fn draw_menubar(
     fb_height: u32,
     show_data_rate: bool,
     client_cursor: bool,
+    show_windows: bool,
     fullscreen: bool,
     data_rate: u64,
+    window_count: usize,
     hovered: Option<BarItem>,
 ) -> BarLayout {
     let stride = fb_width as usize;
@@ -430,7 +443,7 @@ pub fn draw_menubar(
     let mut item_rects: Vec<(BarItem, u32, u32)> = Vec::new();
 
     for item in BAR_ITEMS {
-        let label = item.label(show_data_rate, client_cursor, fullscreen, data_rate);
+        let label = item.label(show_data_rate, client_cursor, show_windows, fullscreen, data_rate, window_count);
         let text_w = label.chars().count() * char_w;
         let item_w = text_w;
 
@@ -443,6 +456,7 @@ pub fn draw_menubar(
         let color = match item {
             BarItem::DataRate if show_data_rate => BAR_ON_FG,
             BarItem::ClientCursor if client_cursor => BAR_ON_FG,
+            BarItem::Windows if show_windows => BAR_ON_FG,
             _ => BAR_TEXT,
         };
         draw_text(buf, stride, x, 4, &label, color);
@@ -470,4 +484,158 @@ pub fn hit_test_menubar(layout: &BarLayout, x: f64, y: f64) -> Option<BarItem> {
         }
     }
     None
+}
+
+// ─── Window list ──────────────────────────────────────────────────────────
+
+/// Draw the session's window list as a panel under the menubar.
+///
+/// This exists because the *in-session* taskbar cannot show it. KDE's task
+/// manager speaks only `org_kde_plasma_window_management`, a KWin protocol, so
+/// on labwc it lists nothing no matter what the session is running (issue #1).
+/// The server reads the standard `zwlr_foreign_toplevel_management_v1` list
+/// instead and sends it over, so the client can render it locally — which also
+/// means it works for `App` (kiosk) sessions that have no panel at all.
+pub fn draw_window_list(
+    buf: &mut [u32],
+    fb_width: u32,
+    fb_height: u32,
+    windows: &[termland_protocol::WindowInfo],
+    top_offset: u32,
+) {
+    let stride = fb_width as usize;
+    let char_w = 8 * 2usize;
+    let line_h = 20usize;
+
+    let title = if windows.is_empty() {
+        "No windows".to_string()
+    } else {
+        format!("Windows ({})", windows.len())
+    };
+
+    // Width tracks the longest line so long titles are not clipped, but stays
+    // within a third of the screen — this overlays the remote desktop, and a
+    // panel wide enough to hide what you are working on defeats the point.
+    let max_chars = windows
+        .iter()
+        .map(|w| display_line(w).chars().count())
+        .chain(std::iter::once(title.chars().count()))
+        .max()
+        .unwrap_or(10);
+    let max_w = (fb_width as usize / 3).max(200);
+    let panel_w = ((max_chars * char_w) + 24).min(max_w);
+    let panel_h = 12 + line_h + (windows.len().max(1) * line_h) + 8;
+
+    let x = 8usize;
+    let y = top_offset as usize + 8;
+    if y + panel_h >= fb_height as usize || panel_w >= fb_width as usize {
+        return; // Not enough room; drawing a clipped panel is worse than none.
+    }
+
+    fill_rect_alpha(buf, stride, x, y, panel_w, panel_h, BAR_BG, 220);
+    draw_rect_outline(buf, stride, x, y, panel_w, panel_h, BAR_BORDER);
+    draw_text(buf, stride, x + 10, y + 8, &title, 0x89B4FA);
+
+    let usable_chars = (panel_w.saturating_sub(24)) / char_w;
+    for (i, w) in windows.iter().enumerate() {
+        let row_y = y + 10 + line_h + (i * line_h);
+        // The focused window is the one a user is looking for, so mark it
+        // rather than relying on colour alone.
+        let color = if w.activated { BAR_ON_FG } else { BAR_TEXT };
+        let line = truncate(&display_line(w), usable_chars);
+        draw_text(buf, stride, x + 10, row_y, &line, color);
+    }
+}
+
+/// One window's row: focus marker, state, then title (falling back to app id).
+fn display_line(w: &termland_protocol::WindowInfo) -> String {
+    let marker = if w.activated { ">" } else { " " };
+    let state = if w.minimized {
+        "_ "
+    } else if w.fullscreen {
+        "[] "
+    } else if w.maximized {
+        "^ "
+    } else {
+        ""
+    };
+    // A window that has mapped but not yet set a title is normal during
+    // startup; showing the app id beats showing an empty row.
+    let name = if !w.title.is_empty() {
+        w.title.as_str()
+    } else if !w.app_id.is_empty() {
+        w.app_id.as_str()
+    } else {
+        "(untitled)"
+    };
+    format!("{marker} {state}{name}")
+}
+
+/// Truncate to `max` characters, marking that it was cut.
+fn truncate(s: &str, max: usize) -> String {
+    if s.chars().count() <= max || max < 2 {
+        return s.to_string();
+    }
+    let kept: String = s.chars().take(max - 1).collect();
+    format!("{kept}…")
+}
+
+#[cfg(test)]
+mod window_list_tests {
+    use super::*;
+    use termland_protocol::WindowInfo;
+
+    fn win(title: &str, app_id: &str, activated: bool) -> WindowInfo {
+        WindowInfo {
+            id: 1,
+            title: title.into(),
+            app_id: app_id.into(),
+            minimized: false,
+            maximized: false,
+            fullscreen: false,
+            activated,
+        }
+    }
+
+    /// A window that has mapped but not yet titled itself must still produce a
+    /// readable row — an empty line looks like a rendering bug.
+    #[test]
+    fn untitled_window_falls_back_to_app_id() {
+        let line = display_line(&win("", "org.kde.konsole", false));
+        assert!(line.contains("org.kde.konsole"), "got {line:?}");
+    }
+
+    #[test]
+    fn window_with_neither_title_nor_app_id_still_renders() {
+        let line = display_line(&win("", "", false));
+        assert!(line.contains("(untitled)"), "got {line:?}");
+    }
+
+    #[test]
+    fn focused_window_is_marked() {
+        assert!(display_line(&win("Konsole", "x", true)).starts_with('>'));
+        assert!(!display_line(&win("Konsole", "x", false)).starts_with('>'));
+    }
+
+    #[test]
+    fn truncation_marks_that_it_cut() {
+        let long = "a".repeat(100);
+        let out = truncate(&long, 10);
+        assert_eq!(out.chars().count(), 10);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn short_lines_are_left_alone() {
+        assert_eq!(truncate("konsole", 40), "konsole");
+    }
+
+    /// Multi-byte titles are common (CJK, emoji in window titles). Truncation
+    /// is by character, so it must not split a codepoint.
+    #[test]
+    fn truncation_is_character_wise_not_byte_wise() {
+        let s = "日本語のウィンドウタイトル";
+        let out = truncate(s, 5);
+        assert_eq!(out.chars().count(), 5);
+    }
 }

--- a/crates/termland-compositor/src/lib.rs
+++ b/crates/termland-compositor/src/lib.rs
@@ -7,9 +7,11 @@ mod cursor_capture;
 mod output_resize;
 mod screencopy;
 mod session;
+mod toplevels;
 pub mod input;
 
 pub use session::{Compositor, CompositorConfig, CompositorError, SessionMode};
 pub use input::InputInjector;
 pub use backend::validate_shell_command;
 pub use cursor_capture::{CursorCapture, CursorCaptureError, CursorCapturer};
+pub use toplevels::{Toplevel, ToplevelError, ToplevelWatcher};

--- a/crates/termland-compositor/src/toplevels.rs
+++ b/crates/termland-compositor/src/toplevels.rs
@@ -1,0 +1,385 @@
+//! Window (toplevel) enumeration via zwlr_foreign_toplevel_management_v1.
+//!
+//! Lets the server tell a client what windows are open inside a session, so the
+//! client can offer a task list / window switcher — see issue #1.
+//!
+//! # Why this is done here rather than left to the in-session panel
+//!
+//! Issue #1 recorded that KDE's taskbar cannot enumerate windows in a Termland
+//! session, and guessed this was a labwc limitation. It is not: labwc (0.9.6,
+//! checked) implements both `zwlr_foreign_toplevel_management_v1` and
+//! `ext_foreign_toplevel_list_v1`. KDE's `libtaskmanager` binds neither — it
+//! speaks only `org_kde_plasma_window_management`, a KDE protocol implemented
+//! by KWin. So a Plasma taskbar cannot work on any wlroots-based compositor,
+//! and no labwc release will change that.
+//!
+//! Since labwc *does* publish the standard protocol, the window list is
+//! available to us as an ordinary Wayland client. Surfacing it over Termland's
+//! own protocol means the feature works regardless of which panel — if any —
+//! runs inside the session, and it works for `App` (cage kiosk) sessions that
+//! have no panel at all.
+//!
+//! # Scope
+//!
+//! Enumeration and state only: title, app id, and whether a window is
+//! minimised, maximised, fullscreen or focused. The protocol also supports
+//! activating and closing windows; that is deliberately not wired up here,
+//! because acting on a window is a bigger surface (it needs a seat, and it
+//! needs thought about what a remote client should be allowed to do) and is
+//! better reviewed on its own.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use wayland_client::protocol::wl_registry;
+use wayland_client::{Connection, Dispatch, Proxy, QueueHandle};
+use wayland_protocols_wlr::foreign_toplevel::v1::client::{
+    zwlr_foreign_toplevel_handle_v1, zwlr_foreign_toplevel_manager_v1,
+};
+
+#[derive(Debug, thiserror::Error)]
+pub enum ToplevelError {
+    #[error("wayland connect: {0}")]
+    Connect(String),
+    #[error("compositor does not implement zwlr_foreign_toplevel_management_v1")]
+    NoManager,
+}
+
+/// One window inside the session.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Toplevel {
+    /// Stable for the lifetime of the window, assigned by us. The protocol
+    /// identifies windows by object, which does not survive being sent over
+    /// the wire, so callers get an integer they can refer back to.
+    pub id: u32,
+    pub title: String,
+    /// Application identifier, e.g. `konsole`. Clients use this to pick an
+    /// icon; it is frequently the desktop-entry name but is not guaranteed to
+    /// be, so treat a miss as "no icon" rather than an error.
+    pub app_id: String,
+    pub minimized: bool,
+    pub maximized: bool,
+    pub fullscreen: bool,
+    pub activated: bool,
+}
+
+/// Wayland client that tracks the compositor's toplevel list.
+///
+/// Like the other helpers in this crate this is a *separate* Wayland client
+/// connection to the session's compositor, not a second use of the capture
+/// connection: the protocols are independent and a failure here must not be
+/// able to disturb the video path.
+pub struct ToplevelWatcher {
+    _conn: Connection,
+    event_queue: wayland_client::EventQueue<State>,
+    state: State,
+}
+
+#[derive(Default)]
+struct State {
+    manager: Option<zwlr_foreign_toplevel_manager_v1::ZwlrForeignToplevelManagerV1>,
+    /// Windows by protocol object id. Keyed this way because every event
+    /// (title, app_id, state, closed) arrives against the handle object.
+    windows: HashMap<u32, Toplevel>,
+    /// Monotonic id source for `Toplevel::id`. Never reused, so a stale id
+    /// from a client refers to nothing rather than to a different window.
+    next_id: u32,
+    /// Set when the compositor finishes a burst of updates, so callers can
+    /// tell "no windows yet" from "no windows".
+    settled: bool,
+}
+
+impl State {
+    fn entry(&mut self, key: u32) -> &mut Toplevel {
+        let next = &mut self.next_id;
+        self.windows.entry(key).or_insert_with(|| {
+            *next += 1;
+            Toplevel { id: *next, ..Default::default() }
+        })
+    }
+}
+
+impl ToplevelWatcher {
+    /// Connect to the session compositor and start tracking its windows.
+    ///
+    /// `runtime_dir` must be the compositor's *actual* runtime dir — see
+    /// `ScreenCapturer::connect` for why this cannot be assumed to be this
+    /// process's own under session isolation.
+    ///
+    /// Returns `NoManager` on a compositor without the protocol. Callers
+    /// should treat that as "window enumeration unavailable" and carry on:
+    /// this is an optional capability, exactly like `OutputResizer`.
+    pub fn connect(display_name: &str, runtime_dir: &Path) -> Result<Self, ToplevelError> {
+        let socket_path = runtime_dir.join(display_name);
+        let stream = std::os::unix::net::UnixStream::connect(&socket_path)
+            .map_err(|e| ToplevelError::Connect(format!("{}: {e}", socket_path.display())))?;
+        let conn =
+            Connection::from_socket(stream).map_err(|e| ToplevelError::Connect(e.to_string()))?;
+
+        let mut event_queue = conn.new_event_queue();
+        let qh = event_queue.handle();
+        let mut state = State::default();
+
+        let _registry = conn.display().get_registry(&qh, ());
+
+        // First roundtrip discovers the manager global.
+        event_queue
+            .roundtrip(&mut state)
+            .map_err(|e| ToplevelError::Connect(format!("roundtrip: {e}")))?;
+
+        if state.manager.is_none() {
+            return Err(ToplevelError::NoManager);
+        }
+
+        // The compositor announces existing windows immediately after bind,
+        // each followed by its title/app_id/state. One more roundtrip picks up
+        // that initial burst so a caller that polls straight away sees the
+        // windows that were already open.
+        event_queue
+            .roundtrip(&mut state)
+            .map_err(|e| ToplevelError::Connect(format!("roundtrip toplevels: {e}")))?;
+
+        tracing::info!(
+            "ToplevelWatcher ready on {display_name} ({} window(s))",
+            state.windows.len()
+        );
+
+        Ok(Self { _conn: conn, event_queue, state })
+    }
+
+    /// Drain pending compositor events and return the current window list.
+    ///
+    /// Non-blocking: this is meant to be called on the same cadence as
+    /// anything else polling the session, and never waits for a window to
+    /// appear.
+    pub fn poll(&mut self) -> Result<Vec<Toplevel>, ToplevelError> {
+        self.event_queue
+            .dispatch_pending(&mut self.state)
+            .map_err(|e| ToplevelError::Connect(format!("dispatch: {e}")))?;
+        // A flush is needed because dispatch_pending only reads what has
+        // already been buffered; without it our bind/ack traffic can sit
+        // unsent and the compositor never tells us about new windows.
+        let _ = self.event_queue.flush();
+        Ok(self.windows())
+    }
+
+    /// Wait up to `timeout` for the window list to be non-empty. Only useful
+    /// right after a session starts, when the shell has not mapped its first
+    /// window yet.
+    pub fn poll_until_any(&mut self, timeout: Duration) -> Result<Vec<Toplevel>, ToplevelError> {
+        let deadline = Instant::now() + timeout;
+        loop {
+            self.event_queue
+                .roundtrip(&mut self.state)
+                .map_err(|e| ToplevelError::Connect(format!("roundtrip: {e}")))?;
+            if !self.state.windows.is_empty() || Instant::now() >= deadline {
+                return Ok(self.windows());
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+    }
+
+    /// Current windows, ordered by id so the list is stable between polls
+    /// rather than reflecting hash iteration order.
+    fn windows(&self) -> Vec<Toplevel> {
+        let mut out: Vec<Toplevel> = self.state.windows.values().cloned().collect();
+        out.sort_by_key(|w| w.id);
+        out
+    }
+
+    /// Whether the compositor has finished at least one update burst.
+    pub fn settled(&self) -> bool {
+        self.state.settled
+    }
+}
+
+impl Dispatch<wl_registry::WlRegistry, ()> for State {
+    fn event(
+        state: &mut Self,
+        registry: &wl_registry::WlRegistry,
+        event: wl_registry::Event,
+        _: &(),
+        _: &Connection,
+        qh: &QueueHandle<Self>,
+    ) {
+        if let wl_registry::Event::Global { name, interface, version } = event {
+            if interface == "zwlr_foreign_toplevel_manager_v1" {
+                // v3 carries the events this module reads. Binding lower is
+                // fine — the compositor simply sends fewer of them.
+                let bind_version = version.min(3);
+                state.manager = Some(registry.bind::<
+                    zwlr_foreign_toplevel_manager_v1::ZwlrForeignToplevelManagerV1,
+                    _,
+                    _,
+                >(name, bind_version, qh, ()));
+            }
+        }
+    }
+}
+
+impl Dispatch<zwlr_foreign_toplevel_manager_v1::ZwlrForeignToplevelManagerV1, ()> for State {
+    fn event(
+        state: &mut Self,
+        _: &zwlr_foreign_toplevel_manager_v1::ZwlrForeignToplevelManagerV1,
+        event: zwlr_foreign_toplevel_manager_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        use zwlr_foreign_toplevel_manager_v1::Event;
+        match event {
+            Event::Toplevel { toplevel } => {
+                // Create the entry now so a window with no title yet still
+                // appears in the list rather than being invisible until it
+                // names itself.
+                let key = toplevel.id().protocol_id();
+                state.entry(key);
+            }
+            Event::Finished => {
+                state.manager = None;
+            }
+            _ => {}
+        }
+    }
+
+    // The `toplevel` event creates a handle object, so wayland-client needs to
+    // be told how to build its user data. Same pattern as OutputResizer's
+    // head/mode children.
+    wayland_client::event_created_child!(State, zwlr_foreign_toplevel_manager_v1::ZwlrForeignToplevelManagerV1, [
+        zwlr_foreign_toplevel_manager_v1::EVT_TOPLEVEL_OPCODE => (zwlr_foreign_toplevel_handle_v1::ZwlrForeignToplevelHandleV1, ()),
+    ]);
+}
+
+impl Dispatch<zwlr_foreign_toplevel_handle_v1::ZwlrForeignToplevelHandleV1, ()> for State {
+    fn event(
+        state: &mut Self,
+        handle: &zwlr_foreign_toplevel_handle_v1::ZwlrForeignToplevelHandleV1,
+        event: zwlr_foreign_toplevel_handle_v1::Event,
+        _: &(),
+        _: &Connection,
+        _: &QueueHandle<Self>,
+    ) {
+        use zwlr_foreign_toplevel_handle_v1::Event;
+        let key = handle.id().protocol_id();
+
+        match event {
+            Event::Title { title } => state.entry(key).title = title,
+            Event::AppId { app_id } => state.entry(key).app_id = app_id,
+            Event::State { state: flags } => {
+                // The compositor sends the complete state each time, as an
+                // array of u32 enum values, so every flag is recomputed from
+                // scratch rather than toggled.
+                let w = state.entry(key);
+                w.minimized = false;
+                w.maximized = false;
+                w.fullscreen = false;
+                w.activated = false;
+                for chunk in flags.chunks_exact(4) {
+                    let v = u32::from_ne_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+                    match v {
+                        0 => w.maximized = true,
+                        1 => w.minimized = true,
+                        2 => w.activated = true,
+                        3 => w.fullscreen = true,
+                        _ => {}
+                    }
+                }
+            }
+            Event::Closed => {
+                state.windows.remove(&key);
+            }
+            Event::Done => {
+                state.settled = true;
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ids must never be reused: a client that remembers a window id and asks
+    /// about it after the window closed has to get "gone", not a different
+    /// window that happens to have taken the slot.
+    #[test]
+    fn ids_are_not_reused_after_a_window_closes() {
+        let mut state = State::default();
+
+        let first = state.entry(100).id;
+        state.windows.remove(&100);
+        let second = state.entry(200).id;
+
+        assert_ne!(first, second, "a new window reused a closed window's id");
+        assert!(second > first);
+    }
+
+    /// Every event arrives against the handle object, so repeated lookups for
+    /// the same window must land on the same entry rather than creating one
+    /// per event.
+    #[test]
+    fn repeated_events_for_one_window_share_an_entry() {
+        let mut state = State::default();
+
+        state.entry(7).title = "konsole".into();
+        state.entry(7).app_id = "org.kde.konsole".into();
+
+        assert_eq!(state.windows.len(), 1);
+        let w = &state.windows[&7];
+        assert_eq!(w.title, "konsole");
+        assert_eq!(w.app_id, "org.kde.konsole");
+    }
+
+    /// State is resent in full, so flags must be recomputed rather than
+    /// OR-ed in — otherwise a window that is un-maximised keeps reporting
+    /// maximised forever.
+    #[test]
+    fn state_flags_are_replaced_not_accumulated() {
+        let mut state = State::default();
+        {
+            let w = state.entry(1);
+            w.maximized = true;
+            w.activated = true;
+        }
+
+        // Simulate the recompute the State event performs.
+        {
+            let w = state.entry(1);
+            w.minimized = false;
+            w.maximized = false;
+            w.fullscreen = false;
+            w.activated = false;
+            for v in [1u32] {
+                match v {
+                    0 => w.maximized = true,
+                    1 => w.minimized = true,
+                    2 => w.activated = true,
+                    3 => w.fullscreen = true,
+                    _ => {}
+                }
+            }
+        }
+
+        let w = &state.windows[&1];
+        assert!(w.minimized);
+        assert!(!w.maximized, "stale maximized survived a state update");
+        assert!(!w.activated, "stale activated survived a state update");
+    }
+
+    #[test]
+    fn windows_are_listed_in_stable_id_order() {
+        let mut state = State::default();
+        state.entry(300);
+        state.entry(100);
+        state.entry(200);
+
+        let watcher_windows: Vec<u32> = {
+            let mut out: Vec<Toplevel> = state.windows.values().cloned().collect();
+            out.sort_by_key(|w| w.id);
+            out.into_iter().map(|w| w.id).collect()
+        };
+        assert_eq!(watcher_windows, vec![1, 2, 3]);
+    }
+}

--- a/crates/termland-compositor/tests/toplevel_enumeration.rs
+++ b/crates/termland-compositor/tests/toplevel_enumeration.rs
@@ -1,0 +1,125 @@
+//! Live check that window enumeration works against a real compositor.
+//!
+//! `#[ignore]`d by default: this spawns an actual headless labwc and a real
+//! GUI application, which a CI runner cannot do. Run it on a desktop with:
+//!
+//! ```text
+//! cargo test -p termland-compositor --test toplevel_enumeration -- --ignored --nocapture
+//! ```
+//!
+//! The unit tests in `toplevels.rs` cover the bookkeeping (id stability, state
+//! replacement, entry reuse). They deliberately do not prove that the protocol
+//! exchange works, which is the part that would break if the compositor or the
+//! wayland crates changed — hence this.
+
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use termland_compositor::ToplevelWatcher;
+
+/// Kills the compositor however the test exits, including on a panicking
+/// assertion. Without this a failed run leaves a headless labwc — and whatever
+/// it launched — running forever, which is exactly the leak that bit
+/// `quic_q2_planes`.
+struct LabwcGuard(Child);
+impl Drop for LabwcGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Read labwc's stderr until the startup command echoes its Wayland socket.
+///
+/// Uses the same `TERMLAND_SOCKET:` marker the production launcher relies on
+/// (`backend::startup_command_with_socket_echo`) rather than trying to parse
+/// labwc's own logging, which is not a stable interface.
+fn wait_for_socket(child: &mut Child, timeout: Duration) -> Option<String> {
+    use std::io::{BufRead, BufReader};
+    let stderr = child.stderr.take()?;
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        for line in BufReader::new(stderr).lines().map_while(Result::ok) {
+            eprintln!("[labwc] {line}");
+            if let Some(name) = line.strip_prefix("TERMLAND_SOCKET:") {
+                let _ = tx.send(name.trim().to_string());
+                return;
+            }
+        }
+    });
+    rx.recv_timeout(timeout).ok()
+}
+
+#[test]
+#[ignore = "needs a real headless compositor and a GUI app; run manually on a desktop"]
+fn enumerates_a_real_window_from_labwc() {
+    let runtime_dir: PathBuf = std::env::var("XDG_RUNTIME_DIR")
+        .unwrap_or_else(|_| format!("/run/user/{}", unsafe { libc::getuid() }))
+        .into();
+
+    // A terminal is the least heavyweight thing guaranteed to map a toplevel.
+    let app = ["foot", "konsole", "alacritty", "xterm"]
+        .into_iter()
+        .find(|a| Command::new("which").arg(a).output().is_ok_and(|o| o.status.success()))
+        .expect("no terminal emulator available to open a window with");
+    eprintln!("[test] using {app} as the window to find");
+
+    let child = Command::new("labwc")
+        .arg("-S")
+        .arg(format!(
+            "sh -c 'echo \"TERMLAND_SOCKET:$WAYLAND_DISPLAY\" >&2; exec {app}'"
+        ))
+        .env("WLR_BACKENDS", "headless")
+        .env("WLR_HEADLESS_OUTPUTS", "1")
+        .env("WLR_HEADLESS_OUTPUT_MODE", "1280x720")
+        .env_remove("WAYLAND_DISPLAY")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn labwc");
+
+    // Guard *before* the first fallible step: everything below can panic, and
+    // an unguarded compositor would outlive the test run.
+    let mut guard = LabwcGuard(child);
+
+    let display = wait_for_socket(&mut guard.0, Duration::from_secs(15))
+        .expect("labwc never announced a wayland socket");
+    eprintln!("[test] labwc up on {display}");
+
+    let mut watcher = ToplevelWatcher::connect(&display, &runtime_dir)
+        .expect("labwc must advertise zwlr_foreign_toplevel_management_v1");
+
+    // The terminal needs a moment to actually map its window.
+    let windows = watcher
+        .poll_until_any(Duration::from_secs(15))
+        .expect("polling for toplevels failed");
+
+    eprintln!("[test] enumerated {} window(s): {windows:#?}", windows.len());
+
+    assert!(
+        !windows.is_empty(),
+        "no windows enumerated — labwc advertised the protocol but reported nothing",
+    );
+    assert!(
+        windows.iter().any(|w| !w.app_id.is_empty() || !w.title.is_empty()),
+        "a window was found but carried neither app_id nor title, so a task list \
+         would have nothing to show: {windows:#?}",
+    );
+
+    // Ids must be stable across polls — a task list that re-keys its entries
+    // every refresh cannot track selection.
+    let again = watcher.poll().expect("second poll failed");
+    let before: Vec<u32> = windows.iter().map(|w| w.id).collect();
+    let after: Vec<u32> = again.iter().map(|w| w.id).collect();
+    assert_eq!(before, after, "window ids changed between polls");
+
+    let _ = guard.0.kill();
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(3) {
+        if matches!(guard.0.try_wait(), Ok(Some(_))) {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}

--- a/crates/termland-protocol/src/messages.rs
+++ b/crates/termland-protocol/src/messages.rs
@@ -40,6 +40,8 @@ pub enum MessageId {
     /// whole so the client can paste them as real files. See
     /// [`FileTransferPayload`] for the MVP size/chunking limitation.
     FileTransferData = 0x25,
+    /// Windows currently open inside the session (see [`WindowList`]).
+    WindowList = 0x26,
 
     // Client -> Server data
     KeyEvent = 0x40,
@@ -79,6 +81,7 @@ impl MessageId {
             0x23 => Some(Self::CursorUpdate),
             0x24 => Some(Self::ClipboardData),
             0x25 => Some(Self::FileTransferData),
+            0x26 => Some(Self::WindowList),
             0x40 => Some(Self::KeyEvent),
             0x41 => Some(Self::MouseMove),
             0x42 => Some(Self::MouseButton),
@@ -120,6 +123,7 @@ pub enum Message {
     CursorUpdate(CursorUpdate),
     ClipboardData(ClipboardPayload),
     FileTransferData(FileTransferPayload),
+    WindowList(WindowList),
 
     // Client -> Server input
     KeyEvent(super::input::KeyEvent),
@@ -157,6 +161,7 @@ impl Message {
             Self::CursorUpdate(_) => MessageId::CursorUpdate,
             Self::ClipboardData(_) => MessageId::ClipboardData,
             Self::FileTransferData(_) => MessageId::FileTransferData,
+            Self::WindowList(_) => MessageId::WindowList,
             Self::KeyEvent(_) => MessageId::KeyEvent,
             Self::MouseMove(_) => MessageId::MouseMove,
             Self::MouseButton(_) => MessageId::MouseButton,
@@ -569,6 +574,44 @@ pub struct FileTransferPayload {
     pub files: Vec<FileEntry>,
 }
 
+/// One window open inside the session.
+///
+/// Sourced from `zwlr_foreign_toplevel_management_v1` on the session
+/// compositor, which labwc implements. This exists because the in-session
+/// panel cannot be relied on to show a task list: KDE's taskbar speaks only
+/// `org_kde_plasma_window_management` (a KWin protocol), so on labwc it shows
+/// nothing — see issue #1. Surfacing the list here means a client can offer a
+/// window switcher regardless of which panel, if any, runs in the session,
+/// including `App` (kiosk) sessions that have no panel at all.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowInfo {
+    /// Stable for the window's lifetime and never reused, so a client can
+    /// hold on to it across updates. Not a compositor object id — those do
+    /// not survive being sent over the wire.
+    pub id: u32,
+    pub title: String,
+    /// Application identifier, e.g. `org.kde.konsole`. Usually but not
+    /// always a desktop-entry name, so a client that cannot resolve it to an
+    /// icon should fall back rather than treat it as an error.
+    pub app_id: String,
+    pub minimized: bool,
+    pub maximized: bool,
+    pub fullscreen: bool,
+    /// Whether this window currently has focus.
+    pub activated: bool,
+}
+
+/// Server -> client: the full window list, sent on change rather than on
+/// request.
+///
+/// Always complete, never a delta. A window absent from a later list has
+/// closed. Deltas would need sequencing to survive a dropped update, and the
+/// list is small enough that resending it is cheaper than getting that right.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct WindowList {
+    pub windows: Vec<WindowInfo>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QualityHintMsg {
     pub max_fps: u8,
@@ -891,5 +934,92 @@ mod audio_codec_tests {
                 Some(codec),
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod window_list_tests {
+    use super::*;
+
+    fn reencode<T: Serialize, U: for<'de> Deserialize<'de>>(value: &T) -> U {
+        let mut buf = Vec::new();
+        ciborium::into_writer(value, &mut buf).expect("serialize");
+        ciborium::from_reader(buf.as_slice()).expect("deserialize")
+    }
+
+    fn window(id: u32) -> WindowInfo {
+        WindowInfo {
+            id,
+            title: "bash — Konsole".into(),
+            app_id: "org.kde.konsole".into(),
+            minimized: false,
+            maximized: true,
+            fullscreen: false,
+            activated: true,
+        }
+    }
+
+    /// A new message id must not collide with an existing one, or an older
+    /// peer would route the frame to the wrong handler rather than skipping it.
+    #[test]
+    fn window_list_has_a_distinct_message_id() {
+        let msg = Message::WindowList(WindowList { windows: Vec::new() });
+        assert_eq!(msg.message_id(), MessageId::WindowList);
+        assert_eq!(MessageId::from_u8(0x26), Some(MessageId::WindowList));
+
+        for id in 0x01u8..=0x25 {
+            if let Some(other) = MessageId::from_u8(id) {
+                assert_ne!(other, MessageId::WindowList, "id 0x{id:02x} collides");
+            }
+        }
+    }
+
+    #[test]
+    fn window_list_round_trips() {
+        let list = WindowList { windows: vec![window(1), window(2)] };
+        let parsed: WindowList = reencode(&list);
+        assert_eq!(parsed, list);
+    }
+
+    /// A window that has mapped but not yet named itself is legitimate, and
+    /// must survive the round trip rather than being dropped — otherwise it
+    /// would flicker in and out of a client's task list as it starts up.
+    #[test]
+    fn unnamed_windows_survive_the_round_trip() {
+        let list = WindowList {
+            windows: vec![WindowInfo {
+                id: 9,
+                title: String::new(),
+                app_id: String::new(),
+                minimized: false,
+                maximized: false,
+                fullscreen: false,
+                activated: false,
+            }],
+        };
+        let parsed: WindowList = reencode(&list);
+        assert_eq!(parsed.windows.len(), 1);
+        assert_eq!(parsed.windows[0].id, 9);
+    }
+
+    /// An empty list means "everything closed" and is distinct from never
+    /// having sent one, so it must not be optimised away.
+    #[test]
+    fn empty_window_list_round_trips() {
+        let parsed: WindowList = reencode(&WindowList { windows: Vec::new() });
+        assert!(parsed.windows.is_empty());
+    }
+
+    /// Ids are what a client keys its task-list entries on, so they have to
+    /// survive serialisation exactly — a client tracking selection across
+    /// updates depends on it.
+    #[test]
+    fn window_ids_are_preserved_exactly() {
+        let list = WindowList {
+            windows: vec![window(1), window(7), window(u32::MAX)],
+        };
+        let parsed: WindowList = reencode(&list);
+        let ids: Vec<u32> = parsed.windows.iter().map(|w| w.id).collect();
+        assert_eq!(ids, vec![1, 7, u32::MAX]);
     }
 }

--- a/crates/termland-server/src/transport.rs
+++ b/crates/termland-server/src/transport.rs
@@ -731,6 +731,26 @@ where
     let mut current_width = first_w;
     let mut current_height = first_h;
 
+    // Window enumeration for the client's task list (issue #1). Optional in
+    // exactly the way OutputResizer is: a compositor without
+    // zwlr_foreign_toplevel_management_v1 simply means no window list, never a
+    // failed session.
+    let mut toplevels = match termland_compositor::ToplevelWatcher::connect(
+        &wayland_display,
+        std::path::Path::new(&compositor_runtime_dir),
+    ) {
+        Ok(w) => Some(w),
+        Err(e) => {
+            tracing::info!("Window enumeration unavailable: {e}");
+            None
+        }
+    };
+    let mut last_windows: Vec<termland_protocol::WindowInfo> = Vec::new();
+    // Polled rather than event-driven: the Wayland connection is blocking, and
+    // half a second is well inside what a task list needs while costing
+    // nothing when nothing changes (the list is only sent on change).
+    let mut window_poll = tokio::time::interval(tokio::time::Duration::from_millis(500));
+
     // How this streaming session ends. Default: the client detached (the
     // compositor keeps running and the session stays resumable).
     let mut outcome = SessionOutcome::Detached;
@@ -738,6 +758,44 @@ where
     // Main event loop
     loop {
         tokio::select! {
+            // Window list, sent only when it differs from what the client was
+            // last told — a desktop sitting idle produces no traffic here.
+            _ = window_poll.tick(), if toplevels.is_some() => {
+                let watcher = toplevels.as_mut().expect("guarded by the branch condition");
+                match watcher.poll() {
+                    Ok(list) => {
+                        let windows: Vec<_> = list
+                            .into_iter()
+                            .map(|w| termland_protocol::WindowInfo {
+                                id: w.id,
+                                title: w.title,
+                                app_id: w.app_id,
+                                minimized: w.minimized,
+                                maximized: w.maximized,
+                                fullscreen: w.fullscreen,
+                                activated: w.activated,
+                            })
+                            .collect();
+                        if windows != last_windows {
+                            last_windows.clone_from(&windows);
+                            if let Err(e) = framed
+                                .send(Message::WindowList(termland_protocol::WindowList { windows }))
+                                .await
+                            {
+                                tracing::error!("Failed to send window list: {e}");
+                                break;
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        // Losing this connection must not take the session
+                        // with it; drop the feature and keep streaming.
+                        tracing::warn!("Window enumeration stopped: {e}");
+                        toplevels = None;
+                    }
+                }
+            }
+
             frame = frame_rx.recv() => {
                 let Some(frame) = frame else {
                     // Capture thread ended because the compositor exited.

--- a/crates/termland-server/tests/window_list_e2e.rs
+++ b/crates/termland-server/tests/window_list_e2e.rs
@@ -1,0 +1,151 @@
+//! End-to-end check that a real session actually delivers `WindowList` to a
+//! client.
+//!
+//! `#[ignore]`d: spawns a real server, which starts a real compositor and a
+//! real GUI app. Run on a desktop with:
+//!
+//! ```text
+//! cargo test -p termland-server --test window_list_e2e -- --ignored --nocapture
+//! ```
+//!
+//! `toplevel_enumeration` in termland-compositor proves the Wayland side in
+//! isolation; the protocol tests prove the message round-trips. Neither proves
+//! the server actually *sends* it during a session, which is the part a user
+//! would notice missing.
+
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use futures::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
+use tokio_util::codec::Framed;
+
+use termland_protocol::{
+    AudioCodec, Hello, Message, SessionCreate, SessionMode, TermlandCodec, VideoCodec,
+    PROTOCOL_VERSION,
+};
+
+struct ChildGuard(Child);
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Closes the session the test creates. Same reasoning as `quic_q2_planes`:
+/// compositors are setsid-detached and outlive the server, so killing the
+/// child is not teardown.
+struct SessionGuard {
+    bin: &'static str,
+    id: Option<String>,
+}
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        let Some(id) = self.id.take() else { return };
+        let sink = format!("termland_{}", id.replace('-', "_"));
+        if let Ok(out) = Command::new("pactl").args(["list", "short", "modules"]).output() {
+            for line in String::from_utf8_lossy(&out.stdout).lines() {
+                if line.contains(&format!("sink_name={sink}")) {
+                    if let Some(m) = line.split_whitespace().next() {
+                        let _ = Command::new("pactl").args(["unload-module", m]).output();
+                    }
+                }
+            }
+        }
+        match Command::new(self.bin).args(["--close-session", &id]).output() {
+            Ok(o) if o.status.success() => eprintln!("[test] closed session {id}"),
+            _ => eprintln!("[test] WARNING: could not close session {id} — close it by hand"),
+        }
+    }
+}
+
+#[tokio::test]
+#[ignore = "needs a real compositor and GUI app; run manually on a desktop"]
+async fn a_real_session_delivers_a_window_list() {
+    let port: u16 = 27871;
+    let bin = env!("CARGO_BIN_EXE_termland-server");
+
+    let child = Command::new(bin)
+        .args(["--bind", "127.0.0.1", "--port", &port.to_string()])
+        .env("RUST_LOG", "info")
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn termland-server");
+    let mut server = ChildGuard(child);
+    let mut session = SessionGuard { bin, id: None };
+
+    tokio::time::sleep(Duration::from_millis(800)).await;
+
+    let stream = TcpStream::connect(("127.0.0.1", port)).await.expect("connect");
+    let mut framed = Framed::new(stream, TermlandCodec);
+
+    framed
+        .send(Message::Hello(Hello {
+            protocol_version: PROTOCOL_VERSION,
+            client_name: "window-list-e2e".into(),
+        }))
+        .await
+        .expect("send Hello");
+    match framed.next().await {
+        Some(Ok(Message::HelloAck(_))) => {}
+        other => panic!("expected HelloAck, got {other:?}"),
+    }
+
+    framed
+        .send(Message::SessionCreate(SessionCreate {
+            mode: SessionMode::Desktop,
+            width: 800,
+            height: 600,
+            audio: false,
+            quality: 30,
+            // A bare terminal: enough to map one window, without dragging in a
+            // whole Plasma session.
+            desktop_shell: Some("konsole".into()),
+            encoder_preset: None,
+            encoder_crf: None,
+            encoder_extra_params: None,
+            supported_codecs: VideoCodec::all_preferred(),
+            supported_audio_codecs: AudioCodec::all_preferred(),
+        }))
+        .await
+        .expect("send SessionCreate");
+
+    // Collect until a WindowList arrives, or we give up.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(40);
+    let mut got: Option<termland_protocol::WindowList> = None;
+
+    while tokio::time::Instant::now() < deadline {
+        let Ok(Some(Ok(msg))) =
+            tokio::time::timeout(Duration::from_secs(5), framed.next()).await
+        else {
+            continue;
+        };
+        match msg {
+            Message::SessionReady(sr) => {
+                eprintln!("[test] SessionReady, session_id={}", sr.session_id);
+                session.id = Some(sr.session_id.clone());
+            }
+            Message::WindowList(list) => {
+                eprintln!("[test] WindowList: {list:#?}");
+                if !list.windows.is_empty() {
+                    got = Some(list);
+                    break;
+                }
+            }
+            Message::SessionEnd(se) => panic!("session ended early: {}", se.reason),
+            _ => {}
+        }
+    }
+
+    let list = got.expect(
+        "no non-empty WindowList arrived — the server never reported the session's windows",
+    );
+    assert!(
+        list.windows.iter().any(|w| !w.app_id.is_empty() || !w.title.is_empty()),
+        "a window was reported but had neither app_id nor title: {list:#?}",
+    );
+
+    let _ = server.0.kill();
+}


### PR DESCRIPTION
Addresses #1 — but that issue's premise turns out to be wrong, and that's the most useful thing in this PR.

## #1 is not a labwc restriction

The issue records that the KDE taskbar can't enumerate windows and guesses *"this seems to be a restriction of labwc... maybe an alternative will patch this later."* Checked against the installed versions:

| Component | Protocol |
|---|---|
| **labwc 0.9.6** | implements `zwlr_foreign_toplevel_management_v1` **and** `ext_foreign_toplevel_list_v1` |
| **KDE `libtaskmanager.so.6`** | binds only `org_kde_plasma_window_management` |

That KDE protocol is implemented by **KWin**. labwc already does its part — the Plasma taskbar simply doesn't speak the standard protocol, and therefore cannot work on *any* wlroots-based compositor.

**No labwc release will fix this**, so waiting for one is waiting for nothing. Worth knowing before more time goes into it.

## What this does instead

Since labwc *does* publish the standard protocol, the window list is available to us as an ordinary Wayland client. Reading it server-side and sending it over Termland's own protocol makes the feature independent of whichever panel — if any — runs inside the session, and it works for `App` (cage kiosk) sessions that have no panel at all.

Arguably better than depending on the in-session panel: the client can render a native window switcher rather than a remote-rendered taskbar.

## Design

- **`ToplevelWatcher`** is a separate Wayland client connection, like `OutputResizer` and `CursorCapturer`, so a failure in it can't disturb the video path. Optional in the same way: a compositor without the protocol logs one line and the session continues with no window list. If the connection dies mid-session, the feature is dropped and streaming carries on.
- **Ids are assigned by us and never reused.** The protocol identifies windows by Wayland object, which doesn't survive the wire, and a client holding a stale id must get "gone" rather than a *different* window that took the slot.
- **`WindowList` is sent on change only** — an idle desktop produces no traffic — and is always the complete list, never a delta. Deltas would need sequencing to survive a dropped update; the list is small enough that resending costs less than getting that right.

## Scope

Enumeration and state only (title, app_id, minimised/maximised/fullscreen/focused). The protocol can also **activate and close** windows; that's deliberately excluded — acting on a window needs a seat, and needs thought about what a remote client should be permitted to do. Better reviewed on its own.

## Client UI included

A **"Windows (n)"** menubar item (F10 shows the bar) toggles a panel listing the session's windows — focus marker, state, title.

A menubar item rather than another hotkey on purpose: F10 and F11 are already taken from the remote session, and every key the client intercepts is one the remote desktop can never receive.

The panel is off by default (it overlays the remote screen) and capped at a third of the screen width so a long title can't hide what you're working on. Rows fall back title → app_id → `(untitled)`, because a window that has mapped but not yet named itself is normal during startup and an empty row reads as a rendering bug. Truncation is by character, not byte — CJK and emoji in window titles are ordinary.

> **Note:** this is Termland's *own* window list, rendered client-side. The in-session KDE taskbar still shows nothing and always will, for the protocol reason above.

## ⚠️ Stacked on #11

Based on `feat/audio-codec-negotiation`, not `main` — the end-to-end test constructs a `SessionCreate` with `supported_audio_codecs`, so the dependency is real rather than cosmetic. **Merge #11 first.**

## Verification — against a real compositor

Not just unit-tested. The live test spawns a real headless labwc, opens a terminal in it, and asserts the window comes back properly:

```
Toplevel { id: 1, title: "termland-compositor : bash — Konsole",
           app_id: "org.kde.konsole", activated: true }
```

It also asserts ids stay stable across polls — a task list that re-keys entries every refresh can't track selection.

It's `#[ignore]`d because a CI runner has no compositor:

```
cargo test -p termland-compositor --test toplevel_enumeration -- --ignored --nocapture
```

It kills labwc from a `Drop` guard so a failing assertion can't strand one — the same lesson as #12. (The first version of this test got that wrong and leaked a compositor, which is how I know the guard placement matters.)

Unit tests cover the bookkeeping the live test can't easily force: id non-reuse, state flags being *replaced* rather than accumulated (the compositor resends full state, so an un-maximised window must stop reporting maximised), and stable ordering.

Protocol tests cover the new message id not colliding, round-trips, and the two easy-to-drop cases: an unnamed window that has mapped but not yet titled itself, and an empty list meaning "everything closed".

An end-to-end test also proves a real session actually *delivers* the list to a connected client — the compositor test proves the Wayland exchange and the protocol tests prove the round-trip, but neither proves the server sends it, which is the part a user notices missing:

```
WindowInfo { id: 1, title: "termland-server : bash — Konsole",
             app_id: "org.kde.konsole", activated: true }
```

Full workspace green: **109 tests** with the stack applied.

## Provenance

Written with Claude, per the `Co-Authored-By` trailer and the discussion in #7. The protocol claims above are from `strings` on the installed binaries and a live protocol exchange — the correction to #1's premise is reproducible, not an opinion.

