### PR TITLE
Bump to v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4810,7 +4810,7 @@ dependencies = [
 
 [[package]]
 name = "termland-client"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -4845,7 +4845,7 @@ dependencies = [
 
 [[package]]
 name = "termland-codec"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "ffmpeg-next",
  "libc",
@@ -4858,7 +4858,7 @@ dependencies = [
 
 [[package]]
 name = "termland-compositor"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "libc",
  "nix 0.29.0",
@@ -4873,7 +4873,7 @@ dependencies = [
 
 [[package]]
 name = "termland-mobile-core"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "futures",
@@ -4892,7 +4892,7 @@ dependencies = [
 
 [[package]]
 name = "termland-protocol"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "ciborium",
@@ -4904,7 +4904,7 @@ dependencies = [
 
 [[package]]
 name = "termland-server"
-version = "0.6.1"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2024"
 license = "LGPL-3.0-or-later"
 rust-version = "1.85"

--- a/README.md
+++ b/README.md
@@ -324,6 +324,34 @@ The client RPM installs:
 
 See [ROADMAP.md](ROADMAP.md) for the full detail behind each item.
 
+## Maintainers wanted
+
+Termland has one maintainer, which means every change is reviewed and merged by
+the person who wrote it. That has been workable while the project was small. It
+is not a good long-term arrangement for something people are now running on
+their machines: a second pair of eyes catches things the author cannot, and a
+single maintainer is also a single point of failure for security reports and
+releases.
+
+If you would like to help review and merge, please open an issue or say so on
+an existing one. Useful background, in rough order of how much it helps:
+
+- **Wayland compositor internals** — `termland-compositor` drives labwc/cage
+  over wlroots protocols (screencopy, output management, virtual input,
+  foreign-toplevel). Most of the hard bugs live here.
+- **Video/audio codecs and FFmpeg** — encoder/decoder backend selection and
+  fallback in `termland-codec`.
+- **RPM packaging and systemd** — the service unit's sandboxing has already
+  been the cause of three separate user-facing bugs.
+- **Android/Kotlin** — the mobile client and its UniFFI core.
+- **Testing** — see [#4](https://github.com/jboero/termland/issues/4) and
+  [#6](https://github.com/jboero/termland/issues/6); coverage is thin in
+  places and the honest boundary of what is worth testing is still being drawn.
+
+Reviewing a pull request or reproducing a bug report is genuinely useful and
+does not require any commitment beyond that. Contributions are AI-assisted;
+see [AGENTS.md](AGENTS.md) for how that is recorded and reviewed.
+
 ## License
 
 LGPL-3.0-or-later

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -167,8 +167,8 @@ android {
         // requestPointerCapture() are all reliably present.
         minSdk = 26
         targetSdk = 35
-        versionCode = 1
-        versionName = "0.6.1"
+        versionCode = 2
+        versionName = "0.7.0"
         ndk { abiFilters += abis }
     }
 

--- a/packaging/build-rpms.sh
+++ b/packaging/build-rpms.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VERSION=0.6.1
+VERSION=0.7.0
 SRCDIR="$(cd "$(dirname "$0")/.." && pwd)"
 SPECDIR="$SRCDIR/packaging"
 

--- a/packaging/make-vendor-tarball.sh
+++ b/packaging/make-vendor-tarball.sh
@@ -24,7 +24,7 @@
 #   packaging/make-vendor-tarball.sh [OUTDIR]   # default: ~/rpmbuild/SOURCES
 set -e
 
-VERSION=0.6.1
+VERSION=0.7.0
 SRCDIR="$(cd "$(dirname "$0")/.." && pwd)"
 OUT="${1:-$HOME/rpmbuild/SOURCES}"
 mkdir -p "$OUT"

--- a/packaging/termland-client.spec
+++ b/packaging/termland-client.spec
@@ -8,14 +8,14 @@
 # COPR: upload this spec + source tarball for automated builds.
 
 %global crate_name termland
-%global version 0.6.1
+%global version 0.7.0
 # See termland-server.spec's comment: EL8's rpmbuild fails hard on the empty
 # debugsourcefiles.list find-debuginfo can produce for a Rust binary.
 %global debug_package %{nil}
 
 Name:           termland-client
 Version:        %{version}
-Release:        2%{?dist}
+Release:        1%{?dist}
 Summary:        Termland remote desktop client — view and interact with remote Wayland sessions
 
 License:        LGPL-3.0-or-later
@@ -138,6 +138,14 @@ install -Dm644 termland-client.fish %{buildroot}%{_datadir}/fish/vendor_completi
 %{_datadir}/fish/vendor_completions.d/termland-client.fish
 
 %changelog
+* Fri Aug 14 2026 John Boero - 0.7.0-1
+- Negotiate the audio codec with the server instead of assuming Opus.
+  Wire-compatible in both directions; Opus remains the only codec.
+- Receive the session's window list, so a task list / window switcher can be
+  built on top of it.
+- Opus frame size is now derived from the sample rate, and an unusable audio
+  configuration is rejected at build time rather than at first use.
+
 * Thu Aug 6 2026 John Boero - 0.6.1-2
 - Same packaging fixes as termland-server 0.6.2 (debuginfo generation
   disabled for EL8, portable /usr/bin/perl BuildRequires for Mageia); no

--- a/packaging/termland-server.spec
+++ b/packaging/termland-server.spec
@@ -8,7 +8,7 @@
 # COPR: upload this spec + source tarball for automated builds.
 
 %global crate_name termland
-%global version 0.6.1
+%global version 0.7.0
 # find-debuginfo can produce an empty debugsourcefiles.list for a Rust
 # binary (unlike typical C sources), which newer Fedora's rpmbuild tolerates
 # but EL8's treats as a hard error ("Empty %%files file ... debugsourcefiles
@@ -20,7 +20,7 @@
 
 Name:           termland-server
 Version:        %{version}
-Release:        2%{?dist}
+Release:        1%{?dist}
 Summary:        Termland remote desktop server — stream Wayland sessions via AV1/VP9/HEVC/H.264/Opus
 
 License:        LGPL-3.0-or-later
@@ -186,6 +186,38 @@ echo ""
 %{_datadir}/fish/vendor_completions.d/termland-server.fish
 
 %changelog
+* Fri Aug 14 2026 John Boero - 0.7.0-1
+- Fix service sandboxing that blocked session startup and cert generation.
+  ProtectHome=read-only covers /home, /root AND /run/user, all three of which
+  the server must write. This was the single cause of three user reports:
+  first-run TLS cert generation failing, the compositor dying before it could
+  create its Wayland socket, and a session failing with a misleading
+  "No such file or directory" for its logfile.
+- TLS keypair moves to /etc/pki/termland/ and is generated at install time via
+  the new "termland-server --generate-cert", since the hardened service cannot
+  write /etc. An existing keypair under /root/.config/termland/ is still used,
+  so upgrades do not change a fingerprint clients have already pinned.
+- Session registry and compositor logs move from /run/user/<uid> to
+  RuntimeDirectory=termland. logind creates /run/user/0 only for a real root
+  login and removes it when the last one ends, deleting live state under a
+  running service.
+- Sessions no longer hijack the machine's default audio sink. Applications in a
+  session are routed with PULSE_SINK instead, so starting a session no longer
+  silences the local desktop, and a crashed server no longer leaves the default
+  pointed at a dead sink.
+- Negotiate the audio codec instead of assuming Opus. Wire-compatible in both
+  directions; Opus remains the only codec.
+- Enumerate session windows and send them to the client, so a client can offer
+  a task list. KDE's own taskbar cannot do this on labwc: it speaks only
+  org_kde_plasma_window_management, which is a KWin protocol.
+- Document the wire protocol and its data structures in docs/protocol.md.
+- Add CI, and stop the integration tests stranding a desktop session per run.
+
+  UPGRADE NOTE: the runtime directory move means detached sessions created by a
+  pre-0.7.0 server are not visible to the new one. Their compositors keep
+  running, orphaned. Close sessions before upgrading, or terminate the
+  leftover compositor processes by hand afterwards.
+
 * Thu Aug 6 2026 John Boero - 0.6.1-2
 - Disable debuginfo package generation (%%global debug_package %%{nil}):
   find-debuginfo produces an empty debugsourcefiles.list for this Rust


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge last.** The changelog describes what's in #9–#16; anything not merged should be struck from it before this goes in.

## Why 0.7.0 and not 0.6.2

Under 0.x the minor field carries breaking change, and this clears that bar: the default TLS cert location moves, there's a new CLI flag, session state moves to a different directory, and audio codec negotiation is new. 0.6.2 would undersell it.

Note your last bump was a *Release* bump (`0.6.1-2`), not a version bump — so `Release:` resets to **1** here. Without that the spec would have built `0.7.0-2` while its own changelog said `0.7.0-1`. `rpmspec` now reports `0.7.0-1` for both packages, matching.

## Six places, plus versionCode

Easy to miss one, so for the record:

| Location | Change |
|---|---|
| `Cargo.toml` (+ `Cargo.lock`) | `0.6.1` → `0.7.0` |
| `packaging/termland-server.spec` | `%global version`, `Release: 1`, changelog |
| `packaging/termland-client.spec` | `%global version`, `Release: 1`, changelog |
| `packaging/build-rpms.sh` | `VERSION=` |
| `packaging/make-vendor-tarball.sh` | `VERSION=` |
| `android/app/build.gradle.kts` | `versionName`, **and `versionCode` 1 → 2** |

`versionCode` matters independently — Play rejects a rebuild at the same code.

## ⚠️ The upgrade note

The changelog leads with this rather than burying it:

> Detached sessions created by a **pre-0.7.0 server are not visible to the new one.** Their compositors keep running, orphaned. Close sessions before upgrading, or terminate the leftover processes by hand afterwards.

This is a consequence of moving session state off `/run/user/<uid>` (which logind deletes when the last root login ends) onto `RuntimeDirectory=`. It only affects hosts where the service currently starts at all — which the sandboxing bug in #9 makes a small set.

## Maintainers wanted

Added to the README as discussed. It says plainly that one person reviewing and merging their own changes isn't a good long-term arrangement for software people are running on their machines, lists what background helps most (compositor internals, codecs, RPM/systemd, Android, testing), and makes clear that **reviewing a PR or reproducing a bug is useful on its own** — no ongoing commitment implied.

It also links AGENTS.md, so anyone considering it knows up front how AI assistance is recorded and reviewed here.

## Verification

- `rpmspec -P` parses both specs; both report `0.7.0-1`, matching their changelog entries
- `Cargo.lock` consistent under `--locked` (CI depends on this)
- Workspace unit tests pass (55)

## Provenance

Written with Claude, per the `Co-Authored-By` trailer and the discussion in #7.
