### PR TITLE
Add a logo, badges and a fuller licence section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
+<div align="center">
+
+<img src="docs/logo.svg" alt="" width="128" height="128">
+
 # Termland
 
 **A Wayland remote desktop server that actually works.**
+
+[![Latest release](https://img.shields.io/github/v/release/jboero/termland?label=release&color=89B4FA)](https://github.com/jboero/termland/releases/latest)
+[![COPR build](https://copr.fedorainfracloud.org/coprs/boeroboy/mawenzy/package/termland-server/status_image/last_build.png)](https://copr.fedorainfracloud.org/coprs/boeroboy/mawenzy/package/termland-server/)
+[![License: LGPL-3.0-or-later](https://img.shields.io/badge/license-LGPL--3.0--or--later-blue)](LICENSE)
+[![Rust 1.85+](https://img.shields.io/badge/rust-1.85%2B-B7410E)](Cargo.toml)
+[![Platform: Linux · Wayland](https://img.shields.io/badge/platform-Linux%20%C2%B7%20Wayland-89B4FA)](#why-this-exists)
+[![Android client](https://img.shields.io/badge/Android-client-3DDC84)](docs/mobile-clients.md)
+[![Built with Claude](https://img.shields.io/badge/built%20with-Claude-D97757)](AGENTS.md)
+
+</div>
 
 Termland streams full interactive desktop and application sessions over the network using AV1 video, Opus audio, and modern transport security. It exists because Wayland broke remote desktop workflows and nobody fixed them.
 
@@ -326,4 +340,25 @@ See [ROADMAP.md](ROADMAP.md) for the full detail behind each item.
 
 ## License
 
-LGPL-3.0-or-later
+**LGPL-3.0-or-later** — see [LICENSE](LICENSE) for the full text.
+
+In short: you can use, modify and redistribute Termland, including inside
+proprietary products, provided changes *to Termland itself* are published
+under the same licence and users can replace the Termland components. Linking
+against it does not make your own code LGPL. This is the standard copyleft
+arrangement for a library-and-tools project, chosen so downstream distributions
+and desktop environments can adopt it without friction.
+
+Termland bundles no third-party code in-tree; dependencies keep their own
+licences, resolved by Cargo (`cargo tree` / `Cargo.lock` for the current set).
+
+## AI assistance
+
+Termland is written with AI assistance, primarily Anthropic's Claude, directed
+by the maintainer. Attribution is recorded per commit as `Co-Authored-By`
+trailers rather than left to be inferred.
+
+[AGENTS.md](AGENTS.md) documents how that works, what is and is not reproducible
+about it, and why the code should be reviewed on its merits like any other
+contribution — being AI-assisted is not a claim of correctness. Raised
+originally in [#7](https://github.com/jboero/termland/issues/7).

--- a/docs/logo.svg
+++ b/docs/logo.svg
@@ -1,0 +1,45 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512" role="img" aria-label="Termland logo: a display showing a terminal prompt above a streaming wave">
+  <title>Termland</title>
+
+  <!--
+    Palette is the client's own overlay palette (crates/termland-client/src/
+    overlay.rs): tile #181825, accent #89B4FA, text #CDD6F4. The mark and the
+    running application therefore look like the same product.
+
+    Motif: a terminal prompt above a wave — a shell session, and Wayland,
+    inside one display. Deliberately only four elements: this has to stay
+    readable as a 16px favicon, and an earlier draft with radiating "signal"
+    arcs turned to mush at that size.
+
+    Drawn on a filled tile so it holds up on GitHub's light and dark themes
+    rather than depending on the page background.
+  -->
+
+  <defs>
+    <linearGradient id="bezel" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#89B4FA"/>
+      <stop offset="100%" stop-color="#CBA6F7"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Tile -->
+  <rect width="512" height="512" rx="96" fill="#181825"/>
+
+  <!-- Display -->
+  <rect x="72" y="108" width="368" height="252" rx="28"
+        fill="#11111B" stroke="url(#bezel)" stroke-width="16"/>
+
+  <!-- Stand -->
+  <path d="M216 360 h80 v36 h48 a13 13 0 0 1 0 26 H168 a13 13 0 0 1 0-26 h48 z"
+        fill="#CDD6F4"/>
+
+  <!-- Prompt: chevron + cursor bar, upper half, clear of the wave -->
+  <path d="M128 168 l40 34 -40 34" fill="none" stroke="#CDD6F4"
+        stroke-width="18" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M196 236 h84" stroke="#CDD6F4" stroke-width="18" stroke-linecap="round"/>
+
+  <!-- Wave: lower half, full width of the panel -->
+  <path d="M112 300 q34 -56 68 0 t68 0 t68 0 t68 0"
+        fill="none" stroke="#89B4FA" stroke-width="20"
+        stroke-linecap="round" stroke-linejoin="round"/>
+</svg>


### PR DESCRIPTION
> [!NOTE]
> **Stacked on #14.** The Claude badge and the new AI-assistance section both link to `AGENTS.md`, so this would ship a broken link on its own. Merge #14 first.

The front page was a bare `H1` — no licence at a glance, no build status, no sign the project is packaged, and nothing to look at. Fine while it was small; less so now people are finding it.

## Logo

Hand-authored SVG, not generated: a terminal prompt above a wave, inside a display.

It uses the **client's own overlay palette** (`crates/termland-client/src/overlay.rs` — `#181825`, `#89B4FA`, `#CDD6F4`), so the mark and the running application look like the same product rather than two unrelated things.

Deliberately only four elements. My first draft had radiating "signal" arcs and a prompt caret that collided with the wave; rasterising it at 48px showed it turned to mush, so I cut it back. Checked at **320px and 48px** by actually rendering and looking, not by assuming.

## Badges

Every one was checked for a `200` before being committed:

| Badge | Source |
|---|---|
| Latest release | GitHub releases (currently v0.6.1) |
| COPR build | `boeroboy/mawenzy` → `termland-server` |
| Licence | LGPL-3.0-or-later → `LICENSE` |
| Rust 1.85+ | MSRV from `Cargo.toml` |
| Platform | Linux · Wayland |
| Android client | → `docs/mobile-clients.md` |
| Built with Claude | → `AGENTS.md` |

**No CI badge yet, on purpose.** The workflow doesn't exist on `main` until #13 merges, and a badge pointing at a workflow that has never run renders as a broken *no status* image — worse than having no badge. Worth adding in a one-liner once #13 lands.

## Licence section

Was a bare SPDX identifier. Now explains what LGPL-3.0-or-later actually means for someone evaluating adoption: that linking against it does **not** make their code LGPL, but changes to Termland itself must be published. That's the question a downstream packager or desktop environment actually has, and leaving them to interpret an identifier is a small barrier for no reason.

## AI assistance section

A short section pointing at `AGENTS.md`, so the answer to #7 is visible from the front page rather than only inside a file people have to go looking for. It says plainly that AI assistance is not a claim of correctness.

## Provenance

Written with Claude, per the `Co-Authored-By` trailer. The logo is committed as SVG source — readable, diffable, and editable by anyone who wants to change it, rather than an opaque binary.
