### PR TITLE
Run the browser interop test in CI, and unpin wasm-bindgen twice over

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,11 @@ jobs:
         # Kept in sync with BuildRequires in packaging/termland-server.spec and
         # packaging/termland-client.spec — this is the union of the two, plus
         # git, which the checkout action needs inside a container.
+        #
+        # chromium and python3 are test-only, not BuildRequires: web/test-browser.sh
+        # drives a real browser and serves the page with `python3 -m http.server`.
+        # python3 is not implicit — the Fedora base image dropped it when dnf5
+        # replaced the Python-based dnf.
         run: |
           dnf install -y --setopt=install_weak_deps=False \
             git \
@@ -41,16 +46,20 @@ jobs:
             pulseaudio-libs-devel \
             alsa-lib-devel \
             pam-devel \
-            wayland-devel wayland-protocols-devel
+            wayland-devel wayland-protocols-devel \
+            chromium python3
 
       - uses: actions/checkout@v4
 
       - name: Cache cargo registry and build artifacts
         uses: actions/cache@v4
+        # ~/.cargo/bin holds wasm-bindgen-cli. Without it in the cache,
+        # `cargo install` rebuilds that CLI from source on every single run.
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
+            ~/.cargo/bin
             target
           key: ${{ runner.os }}-fedora43-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-fedora43-cargo-
@@ -90,10 +99,29 @@ jobs:
       - name: TypeScript client and wasm protocol tests
         run: |
           dnf install -y --setopt=install_weak_deps=False nodejs npm
-          cargo install wasm-bindgen-cli --version 0.2.114
+          # The bindgen schema is not stable across releases, so the CLI must
+          # match the generated glue exactly. Read the version from the
+          # lockfile rather than hardcoding it here, so bumping the crate
+          # cannot leave CI installing a stale CLI (or vice versa).
+          WB=$(awk '/^name = "wasm-bindgen"$/ { getline; gsub(/[",]/, "", $3); print $3; exit }' \
+                 crates/termland-web/Cargo.lock)
+          echo "wasm-bindgen pinned at ${WB}"
+          cargo install wasm-bindgen-cli --version "$WB"
           export PATH="$HOME/.cargo/bin:$PATH"
           cargo test --manifest-path crates/termland-web/Cargo.toml --lib
           ./web/build.sh
+
+      # The only test that proves a *browser* interoperates. Everything else
+      # in the WebTransport suite drives the listener with a `wtransport`
+      # client, which cannot catch a WebCodecs config the browser rejects,
+      # broken wasm-bindgen glue, or a serverCertificateHashes regression.
+      #
+      # It lives in this job rather than `integration` because it only drives
+      # the handshake -- no session is created, so no compositor is needed --
+      # and this job has already built target/debug/termland-server, web/pkg/
+      # and web/dist/ in the step above.
+      - name: Browser interop (real Chromium)
+        run: ./web/test-browser.sh
 
       - name: Check the RPM specs still parse
         run: |

--- a/crates/termland-web/Cargo.lock
+++ b/crates/termland-web/Cargo.lock
@@ -76,6 +76,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1944426bf7d03f1d14f708785e4b33efd750b36d48a157b836b3efc15ede8e1d"
 
 [[package]]
+name = "futures-task"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd417de3d1d015fc3bfd2b1ea46dfc7bab72ef86f1cc7cc9c78e728b34a6d1fd"
+
+[[package]]
+name = "futures-util"
+version = "0.3.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d50a92467f8ba5dd6e3ee5d4bd04d73ab2e4e1c44474a0674821dfce14b79bc"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,11 +106,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -178,6 +197,12 @@ dependencies = [
  "quote",
  "syn 3.0.4",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "syn"
@@ -278,9 +303,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -291,9 +316,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -301,9 +326,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -314,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]

--- a/crates/termland-web/Cargo.toml
+++ b/crates/termland-web/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 termland-protocol = { path = "../termland-protocol" }
 
-wasm-bindgen = "=0.2.114"
+wasm-bindgen = "0.2"
 js-sys = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.6"

--- a/web/build.sh
+++ b/web/build.sh
@@ -4,16 +4,42 @@
 # client into web/dist/. The sample page (index.html + app.js) is plain JS
 # and is not compiled.
 #
-# Requires: rustc with wasm32-unknown-unknown, wasm-bindgen-cli 0.2.114,
-# Node.js 20+.
+# Requires: rustc with wasm32-unknown-unknown, wasm-bindgen-cli, Node.js 20+.
 #
+# wasm-bindgen's generated glue and its CLI must be the exact same version --
+# the bindgen schema is not stable across releases. The crate's Cargo.lock is
+# the single source of truth for which one that is, so the required version is
+# read from there rather than hardcoded here (a hardcoded pin goes stale and
+# then demands a downgrade of a globally installed tool).
 set -euo pipefail
 cd "$(dirname "$0")"
 
-WASM_BINDGEN_VERSION=0.2.114
+# The wasm-bindgen version Cargo.lock resolves to: the line after `name =
+# "wasm-bindgen"` in that package's stanza.
+locked_wasm_bindgen() {
+  awk '/^name = "wasm-bindgen"$/ { getline; gsub(/[",]/, "", $3); print $3; exit }' \
+    ../crates/termland-web/Cargo.lock
+}
+
+WASM_BINDGEN_VERSION=$(locked_wasm_bindgen)
+[ -n "$WASM_BINDGEN_VERSION" ] || {
+  echo "could not read the wasm-bindgen version from crates/termland-web/Cargo.lock" >&2
+  exit 1
+}
+
 if ! command -v wasm-bindgen >/dev/null; then
   echo "wasm-bindgen not found. Install with:" >&2
   echo "  cargo install wasm-bindgen-cli --version ${WASM_BINDGEN_VERSION}" >&2
+  exit 1
+fi
+
+INSTALLED=$(wasm-bindgen --version | awk '{print $2}')
+if [ "$INSTALLED" != "$WASM_BINDGEN_VERSION" ]; then
+  echo "wasm-bindgen-cli ${INSTALLED} is installed, but Cargo.lock pins ${WASM_BINDGEN_VERSION}." >&2
+  echo "The bindgen schema must match exactly. Either:" >&2
+  echo "  cargo install wasm-bindgen-cli --version ${WASM_BINDGEN_VERSION}" >&2
+  echo "or move the lockfile to your CLI and commit the result:" >&2
+  echo "  cargo update --manifest-path crates/termland-web/Cargo.toml -p wasm-bindgen --precise ${INSTALLED}" >&2
   exit 1
 fi
 

--- a/web/test-browser.sh
+++ b/web/test-browser.sh
@@ -13,8 +13,13 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-CHROME=${CHROME:-$(command -v google-chrome || command -v chromium || true)}
-[ -n "$CHROME" ] || { echo "no chrome/chromium found; set CHROME=..." >&2; exit 1; }
+# chromium-browser is what Fedora (and so the CI container) installs; the
+# other two are what a developer machine is likely to have.
+CHROME=${CHROME:-$(command -v chromium-browser \
+                || command -v google-chrome \
+                || command -v chromium \
+                || true)}
+[ -n "$CHROME" ] || { echo "no chromium/chrome found; set CHROME=..." >&2; exit 1; }
 [ -f web/dist/index.js ] || { echo "run ./web/build.sh first" >&2; exit 1; }
 
 WORK=$(mktemp -d)


### PR DESCRIPTION
Follow-up to #24. Two things: put the browser interop test in CI, and stop the
wasm-bindgen version being pinned in two places that can disagree.

## Run the browser test in CI

`web/test-browser.sh` has never run automatically. Its own header says why it
matters:

> This is the only test that proves a *browser* interoperates. The Rust
> integration tests cover the listener and origin checks, but a Rust
> WebTransport client is not a browser.

Everything else in the WebTransport suite drives the listener with a
`wtransport` client. That validates the listener, the origin/path checks and Q2
framing, but it cannot catch a WebCodecs config the browser rejects, broken
wasm-bindgen glue, or a `serverCertificateHashes` regression — the actual
failure modes of a browser client.

It goes in the `test` job rather than `integration`, because it only drives the
handshake — no session is created, so no compositor is needed — and that job has
already built `target/debug/termland-server`, `web/pkg/` and `web/dist/` by the
time it runs. Cost is about 35 seconds, nearly all of it the script's own
`sleep`s.

Two things this needed, both found by running the real container rather than
reasoning about it:

- **`python3` is no longer in the Fedora base image.** It went away when dnf5
  replaced the Python-based dnf. `test-browser.sh` uses it for
  `python3 -m http.server` and to URL-decode the result beacon, so without it
  the step fails at the last line.
- **Fedora names the binary `chromium-browser`.** The script probed for
  `google-chrome` and `chromium`; neither exists there, so it bailed with "no
  chrome/chromium found". Added `chromium-browser` first in the detection list,
  so the script now works in the container *and* on a Fedora desktop with no
  `CHROME=` override.

## One wasm-bindgen version, not two

`web/build.sh` currently fails on any machine whose `wasm-bindgen-cli` is not
exactly 0.2.114:

```
rust Wasm file schema version: 0.2.114
   this binary schema version: 0.2.127
```

The bindgen schema genuinely is not stable across releases, so the CLI and the
generated glue must match — but the version was hardcoded in three places
(`Cargo.toml` as `=0.2.114`, `build.sh`, and `ci.yml`), and CI hid the problem by
installing the old CLI to match. Green in CI, broken for anyone who cloned it.

Now `Cargo.lock` is the single source of truth. `build.sh` and `ci.yml` both read
the version out of it, and `build.sh` fails with the exact command to run if the
installed CLI disagrees:

```
wasm-bindgen-cli 0.2.127 is installed, but Cargo.lock pins 0.2.114.
The bindgen schema must match exactly. Either:
  cargo install wasm-bindgen-cli --version 0.2.114
or move the lockfile to your CLI and commit the result:
  cargo update --manifest-path crates/termland-web/Cargo.toml -p wasm-bindgen --precise 0.2.127
```

The manifest relaxes to `wasm-bindgen = "0.2"` and the lockfile moves to 0.2.127
(current), so `./web/build.sh` works out of the box on an up-to-date toolchain.
That pulls `js-sys` 0.3.91 → 0.3.104, which adds `futures-util`, `futures-task`
and `slab` to the wasm crate's lockfile — upstream's dependency, and confined to
the wasm crate, which is outside the workspace.

Also added `~/.cargo/bin` to the cache paths. `wasm-bindgen-cli` is installed
there, and without it cached `cargo install` rebuilt it from source on every
single run.

## Verification

Ran the `test` job end to end in a real `fedora:43` container — the same image CI
uses — building from scratch inside it rather than mounting host binaries:

```
### dnf install (CI test-job list + chromium) ###
chromium: chromium-151.0.7922.173-1.fc43.x86_64
### cargo build --workspace --locked ###
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 08s
### wasm-bindgen version from lockfile ###
lockfile pins: 0.2.127
   Installed package `wasm-bindgen-cli v0.2.127`
### wasm crate lib tests ###
test result: ok. 8 passed; 0 failed; 0 ignored
### ./web/build.sh ###
Built web/pkg/ (wasm protocol) and web/dist/ (TS client).
### ./web/test-browser.sh (no CHROME override) ###
browser: OK server=termland-server auth=false
server:  received Hello from termland-web
PASS
```

Also re-ran the rest of the suite on the merged `main` with these changes, on
Fedora 44:

| Check | Result |
|---|---|
| `cargo test --workspace --locked --lib --bins` (`-D warnings`) | 130 pass |
| `cargo build -p termland-protocol --target wasm32` | ok |
| `cargo test --manifest-path crates/termland-web --lib` | 8 pass |
| `cargo test --test wire_compatibility` | 7 pass |
| `cargo test --test web_cross_language` | 1 pass |
| `cargo test --workspace --test '*' -- --include-ignored` | all pass, incl. compositor + WebTransport Q2 |
| `./web/build.sh` (`npm test` + `tsc`) | 18 TS tests pass |
| No sessions leaked | confirmed |
