### PR TITLE
Reap session process groups instead of assuming SIGTERM worked

### DIFF
--- a/crates/termland-compositor/src/backend.rs
+++ b/crates/termland-compositor/src/backend.rs
@@ -508,10 +508,45 @@ pub fn detect_desktop_shell() -> String {
     let terminal = detect_terminal();
 
     if has_program("plasmashell") && has_program("dbus-run-session") {
-        // Start plasmashell (panels/plasmoids) in the background, plus a terminal
-        // in the foreground so something is visible and labwc has a session process
-        // to tie its lifetime to. When the terminal exits, labwc exits.
-        return format!("dbus-run-session sh -c 'plasmashell & exec {terminal}'");
+        // Start plasmashell (panels/plasmoids) in the background, plus a
+        // terminal in the foreground so something is visible and labwc has a
+        // session process to tie its lifetime to. When the terminal exits,
+        // labwc exits.
+        //
+        // Two details here are load-bearing, both learned from stranding
+        // `plasmashell` processes on a developer workstation for hours:
+        //
+        //   --no-respawn   Bare plasmashell restarts itself when it dies, so a
+        //                  stranded instance resurrects indefinitely and no
+        //                  amount of killing settles it. A real Plasma session
+        //                  passes this flag for the same reason.
+        //
+        //   no `exec`      `exec` replaced this shell with the terminal,
+        //                  destroying the only process that could clean up
+        //                  after plasmashell. Keeping the shell costs one
+        //                  process and buys a trap that stops the shell when
+        //                  the terminal exits, instead of orphaning it.
+        //
+        // The `wait` after the `kill` is not decoration. Without it the shell
+        // exits as soon as the signal is sent, `dbus-run-session` tears down
+        // the private session bus, and plasmashell — still shutting down —
+        // aborts inside libdbus:
+        //
+        //     abort <- _dbus_warn_check_failed
+        //           <- QDBusConnectionPrivate::getNameOwnerNoCache
+        //           <- QDBusConnectionPrivate::addSignalHookImpl
+        //
+        // which is a coredump and a KCrash handler on every single teardown.
+        // Waiting keeps the bus alive until plasmashell has finished with it.
+        //
+        // The trap does not run on SIGKILL, so this does not replace reaping
+        // the process group in `registry::close` — it just means the common
+        // case never gets that far.
+        return format!(
+            "dbus-run-session sh -c 'plasmashell --no-respawn & shell=$!; \
+             trap \"kill $shell 2>/dev/null; wait $shell 2>/dev/null\" EXIT INT TERM; \
+             {terminal}'"
+        );
     }
 
     terminal
@@ -519,6 +554,65 @@ pub fn detect_desktop_shell() -> String {
 
 pub mod cage;
 pub mod labwc;
+
+#[cfg(test)]
+mod desktop_shell_tests {
+    use super::*;
+
+    /// Only meaningful where plasmashell is actually detected; elsewhere the
+    /// function returns a bare terminal and there is nothing to assert.
+    fn plasma_command() -> Option<String> {
+        let cmd = detect_desktop_shell();
+        cmd.contains("plasmashell").then_some(cmd)
+    }
+
+    /// Bare plasmashell restarts itself when it dies, so a stranded instance
+    /// resurrects forever and killing it never settles anything.
+    #[test]
+    fn plasmashell_is_launched_with_no_respawn() {
+        let Some(cmd) = plasma_command() else { return };
+        assert!(
+            cmd.contains("plasmashell --no-respawn"),
+            "plasmashell must not be allowed to respawn: {cmd}"
+        );
+    }
+
+    /// `exec` replaced the shell with the terminal, destroying the only
+    /// process that could clean up the backgrounded plasmashell. The shell has
+    /// to survive for the trap to exist at all.
+    #[test]
+    fn the_wrapper_shell_survives_to_run_its_trap() {
+        let Some(cmd) = plasma_command() else { return };
+        assert!(
+            !cmd.contains("exec "),
+            "exec destroys the shell that owns plasmashell: {cmd}"
+        );
+        assert!(cmd.contains("trap "), "no trap to clean up plasmashell: {cmd}");
+        assert!(
+            cmd.contains("EXIT") && cmd.contains("TERM"),
+            "trap must cover normal exit and termination: {cmd}"
+        );
+    }
+
+    /// The command is handed to `sh -c`; if it is not valid shell the session
+    /// dies at startup with a message about syntax rather than about Termland.
+    #[test]
+    fn the_command_is_valid_shell() {
+        let Some(cmd) = plasma_command() else { return };
+        // `sh -n` parses without executing.
+        let inner = cmd
+            .split_once("sh -c '")
+            .and_then(|(_, rest)| rest.strip_suffix('\''))
+            .expect("expected a `sh -c '...'` wrapper");
+        let status = std::process::Command::new("sh")
+            .arg("-n")
+            .arg("-c")
+            .arg(inner)
+            .status()
+            .expect("run sh -n");
+        assert!(status.success(), "not valid shell: {inner}");
+    }
+}
 
 #[cfg(test)]
 mod program_lookup_tests {

--- a/crates/termland-server/src/registry.rs
+++ b/crates/termland-server/src/registry.rs
@@ -252,18 +252,181 @@ pub fn list_alive() -> Vec<SessionRecord> {
     out
 }
 
-/// Terminate a session: signal the whole compositor process group (the
-/// compositor was `setsid`'d, so it leads its own group — this reaps its apps
-/// too), then drop the record + logfile.
+/// How long the process group gets to honour `SIGTERM` before `SIGKILL`.
+///
+/// Generous on purpose: a desktop shell saving state on the way out is doing
+/// something useful, and this only delays a teardown the user already asked
+/// for. It is not generous enough to matter if nothing exits — the escalation
+/// still happens.
+const TERM_GRACE: std::time::Duration = std::time::Duration::from_secs(3);
+
+/// Poll interval while waiting for the group to go away.
+const REAP_POLL: std::time::Duration = std::time::Duration::from_millis(50);
+
+/// What happened when a session's process group was terminated.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Reaped {
+    /// Nothing was running under that group to begin with.
+    AlreadyGone,
+    /// Everything exited on `SIGTERM`.
+    Terminated,
+    /// `SIGTERM` was ignored; `SIGKILL` finished the job.
+    Killed,
+    /// Processes survived even `SIGKILL`. PIDs are the survivors.
+    Survivors(Vec<i32>),
+}
+
+/// Live (non-zombie) members of process group `pgid`, read from `/proc`.
+///
+/// `kill(-pid, 0)` is not usable as the liveness check here: it succeeds for a
+/// group whose only remaining member is an unreaped zombie, which would make
+/// teardown escalate to `SIGKILL` and then report survivors forever. Zombies
+/// hold no resources and own no Wayland connection, so they are not what this
+/// is looking for.
+pub fn group_members(pgid: i32) -> Vec<i32> {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+    let mut found = Vec::new();
+    for entry in entries.flatten() {
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else { continue };
+        let Ok(pid) = name.parse::<i32>() else { continue };
+        let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+            continue;
+        };
+        if let Some((state, pgrp)) = parse_stat_state_and_pgrp(&stat) {
+            if pgrp == pgid && state != 'Z' {
+                found.push(pid);
+            }
+        }
+    }
+    found.sort_unstable();
+    found
+}
+
+/// Pull the state and process-group fields out of a `/proc/<pid>/stat` line.
+///
+/// The comm field (2nd) is wrapped in parentheses and may itself contain
+/// spaces and parentheses, so the fields after it are found by splitting at the
+/// *last* `)` rather than by counting spaces from the start.
+fn parse_stat_state_and_pgrp(stat: &str) -> Option<(char, i32)> {
+    let after_comm = &stat[stat.rfind(')')? + 1..];
+    let mut fields = after_comm.split_whitespace();
+    let state = fields.next()?.chars().next()?;
+    let _ppid = fields.next()?;
+    let pgrp = fields.next()?.parse().ok()?;
+    Some((state, pgrp))
+}
+
+/// Terminate a process group and *confirm* it is gone.
+///
+/// The compositor is `setsid`'d, so it leads its own group and its apps inherit
+/// that group id — including after the compositor itself dies, since orphans
+/// keep their pgid when they are reparented. Signalling the group is therefore
+/// the way to reach a desktop shell whose compositor has already exited.
+///
+/// The confirmation is the point. The previous implementation sent `SIGTERM`,
+/// logged success and deleted the session record without checking anything, and
+/// on this project's own workstation the group did *not* die: orphaned
+/// `plasmashell` processes were left blocked in `drm_syncobj_array_wait_timeout`
+/// waiting on GPU fences from a compositor that no longer existed. They ignored
+/// `SIGTERM` entirely and needed `SIGKILL`. Because the record was already
+/// gone, `--list-sessions` showed nothing and nothing would ever reap them.
+pub fn terminate_group(pgid: i32, grace: std::time::Duration) -> Reaped {
+    if group_members(pgid).is_empty() {
+        return Reaped::AlreadyGone;
+    }
+
+    // Stage 1: the leader alone. For a desktop session the leader is the
+    // compositor, and its startup command shuts the session down in order —
+    // the Plasma wrapper kills plasmashell and waits for it before
+    // `dbus-run-session` tears the private bus down.
+    //
+    // Signalling the whole group up front defeats that: `dbus-daemon` is in
+    // the group too, so it takes SIGTERM at the same moment as plasmashell,
+    // the bus vanishes mid-shutdown, and plasmashell aborts inside libdbus
+    // (`_dbus_warn_check_failed` -> `abort`) leaving a coredump on every
+    // teardown. Giving the leader a head start turns that into a clean exit.
+    unsafe {
+        libc::kill(pgid, libc::SIGTERM);
+    }
+    if wait_for_group_exit(pgid, grace) {
+        return Reaped::Terminated;
+    }
+
+    // Stage 2: anything the leader did not take with it. This is where an
+    // orphaned group with no leader left is reached, since orphans keep the
+    // process-group id when they are reparented.
+    unsafe {
+        libc::kill(-pgid, libc::SIGTERM);
+        libc::kill(pgid, libc::SIGTERM);
+    }
+    if wait_for_group_exit(pgid, grace) {
+        return Reaped::Terminated;
+    }
+
+    tracing::warn!(
+        "process group {pgid} ignored SIGTERM after {:?}; escalating to SIGKILL",
+        grace * 2
+    );
+    unsafe {
+        libc::kill(-pgid, libc::SIGKILL);
+        libc::kill(pgid, libc::SIGKILL);
+    }
+
+    // SIGKILL cannot be caught, so this is short — it only covers the kernel
+    // tearing the processes down, not any handler.
+    if wait_for_group_exit(pgid, std::time::Duration::from_secs(2)) {
+        return Reaped::Killed;
+    }
+
+    // Uninterruptible sleep (D state) survives SIGKILL until the syscall
+    // returns; this is exactly where the stranded compositors were found.
+    Reaped::Survivors(group_members(pgid))
+}
+
+/// Poll until the group has no live members, or the deadline passes.
+fn wait_for_group_exit(pgid: i32, timeout: std::time::Duration) -> bool {
+    let deadline = std::time::Instant::now() + timeout;
+    loop {
+        if group_members(pgid).is_empty() {
+            return true;
+        }
+        if std::time::Instant::now() >= deadline {
+            return false;
+        }
+        std::thread::sleep(REAP_POLL);
+    }
+}
+
+/// Terminate a session and drop its record + logfile.
+///
+/// The record is removed whatever happens, because leaving it behind would
+/// advertise a session that can no longer be attached to. Survivors are logged
+/// at error level with their PIDs so there is something to act on, rather than
+/// disappearing silently as they used to.
 pub fn close(id: &str) {
     if let Some(rec) = read(id) {
         let pid = rec.compositor_pid as libc::pid_t;
-        unsafe {
-            // Negative pid → the whole process group.
-            libc::kill(-pid, libc::SIGTERM);
-            libc::kill(pid, libc::SIGTERM);
+        match terminate_group(pid, TERM_GRACE) {
+            Reaped::AlreadyGone => {
+                tracing::info!("Closed session {id} (compositor pid {pid} was already gone)");
+            }
+            Reaped::Terminated => {
+                tracing::info!("Closed session {id} (compositor pid {pid})");
+            }
+            Reaped::Killed => {
+                tracing::info!("Closed session {id} (compositor pid {pid}, needed SIGKILL)");
+            }
+            Reaped::Survivors(pids) => {
+                tracing::error!(
+                    "Session {id}: process group {pid} survived SIGKILL; still running: {pids:?}. \
+                     These are usually blocked in an uninterruptible GPU wait and will need \
+                     manual attention."
+                );
+            }
         }
-        tracing::info!("Closed session {id} (compositor pid {})", rec.compositor_pid);
     }
     remove(id);
 }
@@ -273,5 +436,150 @@ pub fn describe_mode(mode: &termland_protocol::SessionMode) -> String {
     match mode {
         termland_protocol::SessionMode::Desktop => "desktop".to_string(),
         termland_protocol::SessionMode::App { command, .. } => format!("app: {command}"),
+    }
+}
+
+#[cfg(test)]
+mod reap_tests {
+    use super::*;
+    use std::os::unix::process::CommandExt;
+    use std::process::{Child, Command, Stdio};
+    use std::time::Duration;
+
+    /// Spawns a shell in its own session (so it leads a process group, exactly
+    /// as the detached compositor does) and guarantees the group is gone when
+    /// the test ends, however it ends.
+    struct GroupGuard(Child);
+
+    impl GroupGuard {
+        fn spawn(script: &str) -> Self {
+            let mut cmd = Command::new("sh");
+            cmd.arg("-c").arg(script).stdout(Stdio::null()).stderr(Stdio::null());
+            unsafe {
+                cmd.pre_exec(|| {
+                    // setsid: new session, and this process leads a new group.
+                    if libc::setsid() == -1 {
+                        return Err(std::io::Error::last_os_error());
+                    }
+                    Ok(())
+                });
+            }
+            GroupGuard(cmd.spawn().expect("spawn test group"))
+        }
+
+        fn pgid(&self) -> i32 {
+            self.0.id() as i32
+        }
+
+        /// Give the shell time to start its children before signalling.
+        fn settle(&self) {
+            std::thread::sleep(Duration::from_millis(400));
+        }
+    }
+
+    impl Drop for GroupGuard {
+        fn drop(&mut self) {
+            unsafe {
+                libc::kill(-(self.0.id() as i32), libc::SIGKILL);
+            }
+            let _ = self.0.kill();
+            let _ = self.0.wait();
+        }
+    }
+
+    #[test]
+    fn stat_parsing_survives_a_comm_with_spaces_and_parens() {
+        // The comm field is arbitrary and unescaped; splitting on whitespace
+        // from the left puts every later field in the wrong place.
+        let line = "1234 (weird (name) here) S 1 4321 4321 0 -1 4194304";
+        assert_eq!(parse_stat_state_and_pgrp(line), Some(('S', 4321)));
+    }
+
+    #[test]
+    fn stat_parsing_reads_state_and_pgrp_of_a_normal_line() {
+        let line = "42 (plasmashell) D 1 99 99 0 -1 4194560 1234";
+        assert_eq!(parse_stat_state_and_pgrp(line), Some(('D', 99)));
+    }
+
+    #[test]
+    fn group_members_finds_this_test_process() {
+        let pgid = unsafe { libc::getpgid(0) };
+        let members = group_members(pgid);
+        let me = std::process::id() as i32;
+        assert!(members.contains(&me), "own pid {me} missing from group {pgid}: {members:?}");
+    }
+
+    #[test]
+    fn an_empty_group_is_already_gone() {
+        // A pgid nothing can be using: kernel pids do not reach this.
+        assert_eq!(terminate_group(0x7fff_fffe, Duration::from_millis(200)), Reaped::AlreadyGone);
+    }
+
+    #[test]
+    fn a_cooperative_group_exits_on_sigterm() {
+        let g = GroupGuard::spawn("sleep 60 & sleep 60");
+        g.settle();
+        assert_eq!(terminate_group(g.pgid(), Duration::from_secs(3)), Reaped::Terminated);
+        assert!(group_members(g.pgid()).is_empty());
+    }
+
+    /// The behaviour that was missing: the old code sent SIGTERM, logged
+    /// success and deleted the record. A group that ignores SIGTERM — which is
+    /// what the stranded plasmashell processes did — simply stayed alive.
+    #[test]
+    fn a_group_ignoring_sigterm_is_escalated_to_sigkill() {
+        let g = GroupGuard::spawn("trap '' TERM; sleep 60 & trap '' TERM; wait");
+        g.settle();
+        let result = terminate_group(g.pgid(), Duration::from_millis(400));
+        assert_eq!(result, Reaped::Killed, "SIGTERM-ignoring group was not escalated");
+        assert!(group_members(g.pgid()).is_empty(), "survivors after SIGKILL");
+    }
+
+    /// The actual failure on the workstation: the session leader was already
+    /// gone and its children had been reparented to init. Orphans keep their
+    /// process-group id, so the group is still the handle that reaches them —
+    /// and nothing was using it.
+    #[test]
+    fn orphans_of_a_dead_leader_are_still_reaped() {
+        let mut g = GroupGuard::spawn("sleep 60 & sleep 60 & exit 0");
+        g.settle();
+        let pgid = g.pgid();
+        // The leader has exited; reap it so it is not a zombie holding the id.
+        let _ = g.0.wait();
+
+        let before = group_members(pgid);
+        assert!(
+            !before.is_empty(),
+            "test is not exercising anything: no orphans survived the leader"
+        );
+
+        assert_eq!(terminate_group(pgid, Duration::from_secs(3)), Reaped::Terminated);
+        assert!(group_members(pgid).is_empty(), "orphans survived teardown");
+    }
+
+    /// A zombie leader must not read as a live group: it would make teardown
+    /// escalate to SIGKILL and then report survivors that are not really there.
+    #[test]
+    fn a_zombie_does_not_count_as_a_live_group_member() {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("exit 0").stdout(Stdio::null()).stderr(Stdio::null());
+        unsafe {
+            cmd.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let child = cmd.spawn().expect("spawn");
+        let pid = child.id() as i32;
+        // Deliberately not waited on, so it stays a zombie.
+        std::thread::sleep(Duration::from_millis(300));
+        assert!(
+            group_members(pid).is_empty(),
+            "zombie counted as a live group member"
+        );
+        let mut child = child;
+        let _ = child.wait();
     }
 }

--- a/crates/termland-server/src/transport.rs
+++ b/crates/termland-server/src/transport.rs
@@ -1055,7 +1055,14 @@ where
             tracing::info!("Session {session_id} closed");
         }
         SessionOutcome::Gone => {
-            crate::registry::remove(&session_id);
+            // "Gone" is inferred from the compositor PID alone, and its
+            // children outliving it is precisely the case that stranded
+            // `plasmashell` on a developer workstation: orphans keep the
+            // compositor's process group id when they are reparented, so the
+            // group is still reachable and still has to be reaped. Dropping
+            // the record alone left them running with nothing recording that
+            // they existed.
+            crate::registry::close(&session_id);
             crate::registry::clipboard_files_cleanup(&session_id);
             tracing::info!("Session {session_id} ended (compositor gone)");
         }

--- a/crates/termland-server/tests/session_teardown.rs
+++ b/crates/termland-server/tests/session_teardown.rs
@@ -1,0 +1,500 @@
+//! Teardown must leave nothing running.
+//!
+//! `#[ignore]`d: spawns a real server and a real compositor.
+//!
+//! ```text
+//! cargo test -p termland-server --test session_teardown -- --ignored --nocapture
+//! ```
+//!
+//! The unit tests in `registry.rs` prove the reaping primitive in isolation
+//! against synthetic process groups. These prove the primitive is actually
+//! reached by the two teardown paths a user hits, with a real compositor and a
+//! real backgrounded app in the group — which is the shape that stranded
+//! `plasmashell` on a workstation for hours, because the record was deleted
+//! while the processes lived on.
+
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+use futures::{SinkExt, StreamExt};
+use tokio::net::TcpStream;
+use tokio_util::codec::Framed;
+
+use termland_protocol::{
+    AudioCodec, Hello, Message, SessionCreate, SessionMode, TermlandCodec, VideoCodec,
+    PROTOCOL_VERSION,
+};
+
+struct ChildGuard(Child);
+impl Drop for ChildGuard {
+    fn drop(&mut self) {
+        let _ = self.0.kill();
+        let _ = self.0.wait();
+    }
+}
+
+/// Last-resort cleanup: if an assertion fails mid-test, the session must not
+/// outlive the run — that is the very bug under test.
+struct SessionGuard {
+    bin: &'static str,
+    id: Option<String>,
+    pgid: Option<i32>,
+}
+impl Drop for SessionGuard {
+    fn drop(&mut self) {
+        if let Some(id) = self.id.take() {
+            let _ = Command::new(self.bin).args(["--close-session", &id]).output();
+        }
+        if let Some(pgid) = self.pgid.take() {
+            unsafe {
+                libc::kill(-pgid, libc::SIGKILL);
+            }
+        }
+    }
+}
+
+fn first_on_path(names: &[&str]) -> Option<String> {
+    let path = std::env::var_os("PATH")?;
+    for name in names {
+        for dir in std::env::split_paths(&path) {
+            if std::fs::metadata(dir.join(name)).map(|m| m.is_file()).unwrap_or(false) {
+                return Some((*name).to_string());
+            }
+        }
+    }
+    None
+}
+
+/// Live (non-zombie) members of a process group, read straight from `/proc`.
+///
+/// Deliberately a second implementation rather than a call into the server's
+/// own `registry::group_members`: a test that reuses the code under test
+/// cannot show that the code is right about the system.
+fn group_members(pgid: i32) -> Vec<i32> {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let Ok(pid) = name.parse::<i32>() else { continue };
+        let Ok(stat) = std::fs::read_to_string(format!("/proc/{pid}/stat")) else {
+            continue;
+        };
+        let Some(idx) = stat.rfind(')') else { continue };
+        let mut fields = stat[idx + 1..].split_whitespace();
+        let (Some(state), Some(_ppid), Some(pgrp)) =
+            (fields.next(), fields.next(), fields.next())
+        else {
+            continue;
+        };
+        if pgrp.parse::<i32>() == Ok(pgid) && state != "Z" {
+            out.push(pid);
+        }
+    }
+    out.sort_unstable();
+    out
+}
+
+fn describe(pids: &[i32]) -> String {
+    pids.iter()
+        .map(|p| {
+            let cmd = std::fs::read_to_string(format!("/proc/{p}/cmdline"))
+                .map(|c| c.replace('\0', " ").trim().to_string())
+                .unwrap_or_default();
+            format!("{p} ({cmd})")
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+fn sessions(bin: &str) -> Vec<(String, i32)> {
+    let Ok(out) = Command::new(bin).arg("--list-sessions").output() else {
+        return Vec::new();
+    };
+    String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .skip(1)
+        .filter_map(|line| {
+            let f: Vec<&str> = line.split_whitespace().collect();
+            // SESSION ID  MODE  SIZE  AGE  PID  AUDIO
+            if f.len() < 6 {
+                return None;
+            }
+            Some((f[0].to_string(), f[4].parse().ok()?))
+        })
+        .collect()
+}
+
+/// Start a server and a desktop session whose shell backgrounds a long-lived
+/// process, standing in for `plasmashell`. Returns the guards plus the
+/// session id and compositor pid (which is the process-group id, since the
+/// compositor is `setsid`'d).
+async fn start_session(port: u16) -> (ChildGuard, SessionGuard, String, i32) {
+    let bin = env!("CARGO_BIN_EXE_termland-server");
+    let terminal = first_on_path(&["foot", "konsole", "alacritty", "xterm"])
+        .expect("no terminal emulator available");
+
+    // Server output goes to a file so a failure can print why, rather than
+    // being swallowed by a pipe nothing reads.
+    let log_path = std::env::temp_dir().join(format!("termland-teardown-{port}.log"));
+    let log = std::fs::File::create(&log_path).expect("create server log");
+    let script = std::env::temp_dir()
+        .join(format!("termland-teardown-shell-{port}.sh"))
+        .to_string_lossy()
+        .into_owned();
+    std::fs::write(
+        &script,
+        format!("#!/bin/sh\nsh -c 'trap \"\" TERM; sleep 600' &\nexec {terminal}\n"),
+    )
+    .expect("write session shell script");
+    std::fs::set_permissions(&script, std::os::unix::fs::PermissionsExt::from_mode(0o755))
+        .expect("chmod session shell script");
+
+    let server = ChildGuard(
+        Command::new(bin)
+            .args(["--bind", "127.0.0.1", "--port", &port.to_string()])
+            .env("RUST_LOG", "info")
+            .stdout(Stdio::null())
+            .stderr(Stdio::from(log))
+            .spawn()
+            .expect("spawn termland-server"),
+    );
+    let mut guard = SessionGuard { bin, id: None, pgid: None };
+    tokio::time::sleep(Duration::from_millis(800)).await;
+
+    let stream = TcpStream::connect(("127.0.0.1", port)).await.expect("connect");
+    let mut framed = Framed::new(stream, TermlandCodec);
+    framed
+        .send(Message::Hello(Hello {
+            protocol_version: PROTOCOL_VERSION,
+            client_name: "session-teardown".into(),
+        }))
+        .await
+        .expect("send Hello");
+    match framed.next().await {
+        Some(Ok(Message::HelloAck(_))) => {}
+        other => panic!("expected HelloAck, got {other:?}"),
+    }
+
+    // A wrapper script, not an inline command: the server rejects shell
+    // metacharacters in a client-supplied desktop_shell, which is correct --
+    // a client must not get to inject shell. The auto-detected Plasma command
+    // is server-side and is covered by termland-compositor's unit tests.
+    //
+    // The script backgrounds a process that IGNORES SIGTERM, as a stand-in
+    // for plasmashell. Both halves matter:
+    //
+    //   backgrounded  nothing in the foreground owns it, so it outlives the
+    //                 compositor exactly as the stranded instances did;
+    //   ignores TERM  the stranded plasmashell processes were blocked in
+    //                 drm_syncobj_array_wait_timeout and did not die on
+    //                 SIGTERM. A plain `sleep` does die on SIGTERM, so a test
+    //                 using one passes against the old, broken teardown too --
+    //                 verified by reverting the fix and watching it stay green.
+    //
+    // Spawning a real plasmashell here would put a second Plasma on the
+    // developer's desktop, which is the thing this test exists to stop.
+    framed
+        .send(Message::SessionCreate(SessionCreate {
+            mode: SessionMode::Desktop,
+            width: 640,
+            height: 360,
+            audio: false,
+            quality: 30,
+            desktop_shell: Some(script.clone()),
+            encoder_preset: None,
+            encoder_crf: None,
+            encoder_extra_params: None,
+            supported_codecs: VideoCodec::all_preferred(),
+            supported_audio_codecs: AudioCodec::all_preferred(),
+        }))
+        .await
+        .expect("send SessionCreate");
+
+    let deadline = Instant::now() + Duration::from_secs(45);
+    let mut ready = None;
+    while Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_secs(5), framed.next()).await {
+            Ok(Some(Ok(Message::SessionReady(r)))) => {
+                ready = Some(r);
+                break;
+            }
+            Ok(Some(Ok(_))) => continue,
+            _ => break,
+        }
+    }
+    let ready = ready.unwrap_or_else(|| {
+        let log = std::fs::read_to_string(&log_path).unwrap_or_default();
+        panic!(
+            "session never became ready. Server log:\n{}",
+            log.lines().rev().take(25).collect::<Vec<_>>().into_iter().rev()
+                .collect::<Vec<_>>().join("\n")
+        )
+    });
+    let pgid = sessions(bin)
+        .into_iter()
+        .find(|(id, _)| *id == ready.session_id)
+        .map(|(_, pid)| pid)
+        .expect("session missing from the registry");
+
+    guard.id = Some(ready.session_id.clone());
+    guard.pgid = Some(pgid);
+
+    // The backgrounded stand-in needs a moment to appear in the group.
+    tokio::time::sleep(Duration::from_secs(2)).await;
+    let members = group_members(pgid);
+    assert!(
+        members.len() >= 2,
+        "expected a compositor and its backgrounded app in group {pgid}, saw {}",
+        describe(&members)
+    );
+    eprintln!("[test] session {} group {pgid}: {}", ready.session_id, describe(&members));
+
+    (server, guard, ready.session_id, pgid)
+}
+
+/// Wait for the group to empty, so a slow exit is not read as a leak.
+fn wait_empty(pgid: i32, timeout: Duration) -> Vec<i32> {
+    let deadline = Instant::now() + timeout;
+    loop {
+        let members = group_members(pgid);
+        if members.is_empty() || Instant::now() >= deadline {
+            return members;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+}
+
+#[tokio::test]
+#[ignore = "spawns a real compositor; run manually on a desktop"]
+async fn closing_a_session_leaves_nothing_in_its_process_group() {
+    let (_server, mut guard, id, pgid) = start_session(27881).await;
+    let bin = env!("CARGO_BIN_EXE_termland-server");
+
+    let out = Command::new(bin)
+        .args(["--close-session", &id])
+        .output()
+        .expect("run --close-session");
+    assert!(out.status.success(), "--close-session failed");
+    guard.id = None;
+
+    let survivors = wait_empty(pgid, Duration::from_secs(10));
+    assert!(
+        survivors.is_empty(),
+        "teardown left processes running in group {pgid}: {}",
+        describe(&survivors)
+    );
+    guard.pgid = None;
+
+    assert!(
+        !sessions(bin).iter().any(|(sid, _)| *sid == id),
+        "session {id} is still in the registry after close"
+    );
+    eprintln!("[test] PASS: group {pgid} is empty and the record is gone");
+}
+
+/// The case that actually bit: the compositor dies first, its children are
+/// reparented to init, and teardown has to reach them anyway. Orphans keep
+/// their process-group id, so the group is still the handle — the old code
+/// simply never used it, deleting the record and leaving them running.
+#[tokio::test]
+#[ignore = "spawns a real compositor; run manually on a desktop"]
+async fn orphans_of_a_killed_compositor_are_still_reaped() {
+    let (_server, mut guard, id, pgid) = start_session(27883).await;
+    let bin = env!("CARGO_BIN_EXE_termland-server");
+
+    // Simulate a compositor crash: kill only the leader, hard.
+    unsafe {
+        libc::kill(pgid, libc::SIGKILL);
+    }
+    std::thread::sleep(Duration::from_secs(2));
+
+    let orphans = group_members(pgid);
+    assert!(
+        !orphans.is_empty(),
+        "test proves nothing: nothing outlived the compositor"
+    );
+    eprintln!("[test] orphans after killing the compositor: {}", describe(&orphans));
+
+    let out = Command::new(bin)
+        .args(["--close-session", &id])
+        .output()
+        .expect("run --close-session");
+    assert!(out.status.success(), "--close-session failed");
+    guard.id = None;
+
+    let survivors = wait_empty(pgid, Duration::from_secs(10));
+    assert!(
+        survivors.is_empty(),
+        "orphans of the dead compositor survived teardown in group {pgid}: {}",
+        describe(&survivors)
+    );
+    guard.pgid = None;
+    eprintln!("[test] PASS: orphaned group {pgid} was reaped");
+}
+
+/// The real thing: no `desktop_shell` from the client, so the server picks its
+/// own — which on a KDE host is `dbus-run-session sh -c 'plasmashell
+/// --no-respawn & ...'`. That command is what stranded Plasma instances on a
+/// developer workstation, and it is not reachable from a client-supplied shell
+/// because the server rejects shell metacharacters there.
+///
+/// Skipped where plasmashell is not installed rather than silently passing on
+/// a terminal-only fallback, so a green run means what it looks like.
+#[tokio::test]
+#[ignore = "spawns a real desktop shell; run manually on a KDE desktop"]
+async fn an_auto_detected_plasma_shell_is_fully_reaped() {
+    if first_on_path(&["plasmashell"]).is_none() {
+        eprintln!("[test] SKIP: plasmashell is not installed on this host");
+        return;
+    }
+    let bin = env!("CARGO_BIN_EXE_termland-server");
+    let port = 27885;
+    let plasma_before = plasmashell_pids();
+
+    let log_path = std::env::temp_dir().join(format!("termland-teardown-{port}.log"));
+    let log = std::fs::File::create(&log_path).expect("create server log");
+    let _server = ChildGuard(
+        Command::new(bin)
+            .args(["--bind", "127.0.0.1", "--port", &port.to_string()])
+            .env("RUST_LOG", "info")
+            .stdout(Stdio::null())
+            .stderr(Stdio::from(log))
+            .spawn()
+            .expect("spawn termland-server"),
+    );
+    let mut guard = SessionGuard { bin, id: None, pgid: None };
+    tokio::time::sleep(Duration::from_millis(800)).await;
+
+    let stream = TcpStream::connect(("127.0.0.1", port)).await.expect("connect");
+    let mut framed = Framed::new(stream, TermlandCodec);
+    framed
+        .send(Message::Hello(Hello {
+            protocol_version: PROTOCOL_VERSION,
+            client_name: "session-teardown-plasma".into(),
+        }))
+        .await
+        .expect("send Hello");
+    match framed.next().await {
+        Some(Ok(Message::HelloAck(_))) => {}
+        other => panic!("expected HelloAck, got {other:?}"),
+    }
+    framed
+        .send(Message::SessionCreate(SessionCreate {
+            mode: SessionMode::Desktop,
+            width: 640,
+            height: 360,
+            audio: false,
+            quality: 30,
+            // The point of this test: let the server choose.
+            desktop_shell: None,
+            encoder_preset: None,
+            encoder_crf: None,
+            encoder_extra_params: None,
+            supported_codecs: VideoCodec::all_preferred(),
+            supported_audio_codecs: AudioCodec::all_preferred(),
+        }))
+        .await
+        .expect("send SessionCreate");
+
+    let deadline = Instant::now() + Duration::from_secs(60);
+    let mut ready = None;
+    while Instant::now() < deadline {
+        match tokio::time::timeout(Duration::from_secs(5), framed.next()).await {
+            Ok(Some(Ok(Message::SessionReady(r)))) => {
+                ready = Some(r);
+                break;
+            }
+            Ok(Some(Ok(_))) => continue,
+            _ => break,
+        }
+    }
+    let ready = ready.unwrap_or_else(|| {
+        let log = std::fs::read_to_string(&log_path).unwrap_or_default();
+        panic!("session never became ready. Server log:\n{log}")
+    });
+    let pgid = sessions(bin)
+        .into_iter()
+        .find(|(id, _)| *id == ready.session_id)
+        .map(|(_, pid)| pid)
+        .expect("session missing from the registry");
+    guard.id = Some(ready.session_id.clone());
+    guard.pgid = Some(pgid);
+
+    // Plasma takes a while to come up; wait for it rather than racing it.
+    let plasma_deadline = Instant::now() + Duration::from_secs(30);
+    while Instant::now() < plasma_deadline {
+        if plasmashell_pids().len() > plasma_before.len() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(250));
+    }
+    let during = plasmashell_pids();
+    let spawned: Vec<i32> = during.iter().copied().filter(|p| !plasma_before.contains(p)).collect();
+    eprintln!(
+        "[test] session {} group {pgid}: {}",
+        ready.session_id,
+        describe(&group_members(pgid))
+    );
+    eprintln!("[test] plasmashell spawned by the session: {}", describe(&spawned));
+
+    // Let Plasma finish coming up before tearing it down. Killing it two
+    // seconds into startup, while it is still registering DBus signal hooks
+    // from timers, is a race a real session does not run: TERMLAND_SETTLE_SECS
+    // exists so that difference can be measured rather than assumed.
+    let settle: u64 = std::env::var("TERMLAND_SETTLE_SECS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(15);
+    std::thread::sleep(Duration::from_secs(settle));
+
+    Command::new(bin)
+        .args(["--close-session", &ready.session_id])
+        .output()
+        .expect("run --close-session");
+    guard.id = None;
+
+    let survivors = wait_empty(pgid, Duration::from_secs(15));
+    assert!(
+        survivors.is_empty(),
+        "teardown left processes in group {pgid}: {}",
+        describe(&survivors)
+    );
+    guard.pgid = None;
+
+    // The check that matters to the host: no plasmashell beyond the ones that
+    // were already running before this test started. A survivor here is what
+    // collides with the real session's global shortcuts and takes kded6 down.
+    let after = plasmashell_pids();
+    let leaked: Vec<i32> = after.into_iter().filter(|p| !plasma_before.contains(p)).collect();
+    assert!(
+        leaked.is_empty(),
+        "session stranded plasmashell on the host: {}",
+        describe(&leaked)
+    );
+    eprintln!("[test] PASS: no plasmashell stranded, group {pgid} empty");
+}
+
+/// PIDs of every running `plasmashell`, host-wide.
+fn plasmashell_pids() -> Vec<i32> {
+    let Ok(entries) = std::fs::read_dir("/proc") else {
+        return Vec::new();
+    };
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        let Ok(pid) = name.parse::<i32>() else { continue };
+        if let Ok(cmd) = std::fs::read_to_string(format!("/proc/{pid}/cmdline")) {
+            if cmd.split('\0').next().is_some_and(|a| a.ends_with("plasmashell")) {
+                out.push(pid);
+            }
+        }
+    }
+    out.sort_unstable();
+    out
+}


### PR DESCRIPTION
Fixes #27.

## What was happening

Three separate defects on the teardown path, all needed for the failure:

**1. `registry::close()` never checked that anything died.** It sent `SIGTERM`
to the process group, logged "Closed session", and deleted the record. The
stranded processes were blocked in `drm_syncobj_array_wait_timeout` — waiting
on GPU fences from a compositor that no longer existed — and ignored `SIGTERM`
outright. With the record already gone, `--list-sessions` showed nothing, so
nothing would ever reap them. That is why they accumulated for hours.

**2. `SessionOutcome::Gone` signalled nothing at all**, just `remove()`. "Gone"
is inferred from the compositor PID alone, and its children outliving it is
precisely the observed case. Orphans keep the process-group id when they are
reparented, so the group is still a valid handle — it just was not being used.

**3. The Plasma shell owned nothing.** `plasmashell & exec <terminal>` — `exec`
replaced the shell with the terminal, destroying the only process that could
have cleaned up. And bare `plasmashell` respawns itself, so a stranded instance
resurrects indefinitely no matter how often it is killed. (Your real session
runs `--no-respawn`; this one did not.)

## The crash itself

Every stranded `plasmashell` I reproduced aborted with the same stack:

```
abort ← _dbus_abort ← _dbus_warn_check_failed
      ← QDBusConnectionPrivate::getNameOwnerNoCache
      ← QDBusConnectionPrivate::addSignalHookImpl
```

Same terminal frames as the `kded6` SIGABRTs. The mechanism is ordering:
`dbus-daemon` is *inside* the session's process group, so signalling the group
all at once killed the private session bus while plasmashell was still talking
to it. It aborted rather than exiting — a coredump plus a KCrash handler on
every single teardown.

So there were really two problems stacked: teardown left processes behind, and
teardown crashed the ones it did reach.

## The fix

- Termination is **staged and confirmed**: SIGTERM the leader, then the group,
  then SIGKILL — checking after each stage that the group is actually empty,
  and logging survivors with PIDs instead of reporting success.
- Signalling the compositor first lets its startup command shut the session
  down *in order*, so the bus outlives what is using it.
- The Plasma wrapper runs `plasmashell --no-respawn` under a shell that
  survives to `trap ... EXIT INT TERM`, and `wait`s for it before letting
  `dbus-run-session` tear the bus down.
- Liveness comes from `/proc`, not `kill(-pgid, 0)` — the latter reports a
  group whose only member is an unreaped zombie as alive, which would make
  teardown escalate and then report survivors that are not there.

## Verification

**11 consecutive create-and-close cycles of a real auto-detected Plasma
session** on this host: no stranded processes, no coredumps, and your real
`plasmashell` (PID 7392, up since Aug 27) untouched throughout. Each session
brought up the full stack — plasmashell, dbus-daemon, xdg portals,
kactivitymanagerd, ksystemstats — 19 processes in the group, all reaped.

The tests discriminate rather than merely pass. Both integration tests were run
against the **old** implementation and fail there:

```
teardown left processes running in group 876769: 876774 (sleep 600)
orphans of the dead compositor survived teardown in group 877539: 877573 (sleep 600)
```

An earlier draft used a plain `sleep` as the stand-in and passed against the
old code too — `sleep` dies on `SIGTERM`, so it proved nothing. The stand-in now
ignores `SIGTERM`, matching what the real stranded processes did.

## One thing not fixed

Tearing a session down **two seconds into** Plasma's startup still aborts about
one time in three: plasmashell is mid-DBus-registration and shutdown races it.
Settled sessions are clean (0 in 11); the aggressive case is reproducible with
`TERMLAND_SETTLE_SECS=2` on the new test. I have left it visible rather than
tuned the test until it looked green, since it is a real if narrow race.

Also worth restating from the handover notes: **the static is not explained by
this** and should not be assumed fixed. The crash storm and the static were
correlated, not proven causal. If the static continues after this lands, that
is useful evidence rather than a regression.